### PR TITLE
Add admin approval workflow and overrides

### DIFF
--- a/.github/workflows/admin-approve-submission.yml
+++ b/.github/workflows/admin-approve-submission.yml
@@ -1,0 +1,143 @@
+name: Admin Approve Submission
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  approve:
+    # Only run on issues (not PRs) with submission label when admin comments /approve
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'submission') &&
+      startsWith(github.event.comment.body, '/approve')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check if user is admin/maintainer
+        id: check-permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+
+            const allowed = ['admin', 'maintain', 'write'].includes(permission.permission);
+            console.log(`User ${context.actor} has ${permission.permission} permission. Allowed: ${allowed}`);
+
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} You don't have permission to approve submissions.`
+              });
+            }
+
+            return allowed;
+          result-encoding: string
+
+      - name: Parse approval command
+        if: steps.check-permission.outputs.result == 'true'
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = context.payload.comment.body.trim();
+            // Match /approve or /approve 2 or /approve 3
+            const match = comment.match(/^\/approve(?:\s+(\d))?/);
+
+            if (match) {
+              const scoreOverride = match[1] ? parseInt(match[1]) : null;
+              console.log(`Score override: ${scoreOverride}`);
+              core.setOutput('score_override', scoreOverride || '');
+              core.setOutput('valid', 'true');
+            } else {
+              core.setOutput('valid', 'false');
+            }
+
+      - name: Checkout
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        run: |
+          pip install requests beautifulsoup4 anthropic
+
+      - name: Re-evaluate with admin override
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        id: evaluate
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ADMIN_SCORE_OVERRIDE: ${{ steps.parse.outputs.score_override }}
+          ADMIN_APPROVED: 'true'
+        run: |
+          python scripts/evaluate_submission.py
+
+      - name: Create PR
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          if [ -f submission_data.json ]; then
+            python scripts/create_submission_pr.py
+          else
+            echo "No submission data found"
+            exit 1
+          fi
+
+      - name: Update labels and comment
+        if: steps.check-permission.outputs.result == 'true' && steps.parse.outputs.valid == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Remove old labels
+            const labelsToRemove = ['needs-review', 'rejected'];
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                });
+              } catch (e) {
+                // Label might not exist
+              }
+            }
+
+            // Add approved label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['approved']
+            });
+
+            // Add success comment
+            const scoreOverride = '${{ steps.parse.outputs.score_override }}';
+            const scoreMsg = scoreOverride ? ` with score override to ${scoreOverride}/3` : '';
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ **Approved by @${context.actor}**${scoreMsg}\n\nA PR has been created to add this service to the directory.`
+            });

--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -69,9 +69,11 @@ jobs:
 
             let label = 'needs-review';
             if (score === 3) {
-              label = 'ready-to-merge';
-            } else if (score <= 1) {
-              label = 'rejected';
+              label = 'auto-approved';
+            } else if (score === 2) {
+              label = 'needs-review';
+            } else {
+              label = 'needs-review';  // Even rejected ones go to needs-review for admin decision
             }
 
             await github.rest.issues.addLabels({
@@ -80,6 +82,24 @@ jobs:
               issue_number: context.issue.number,
               labels: [label]
             });
+
+            // Add info comment for low scores
+            if (score < 2) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `⚠️ **Admin Review Required**\n\nThis submission scored ${score}/3 and needs manual verification.\n\n**To approve:** Comment \`/approve\` or \`/approve 3\` (to override score)\n**To reject:** Add the \`rejected\` label and close the issue`
+              });
+            }
+
+      - name: Upload submission data as artifact
+        if: steps.read_outputs.outputs.has_data == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-data-${{ github.event.issue.number }}
+          path: submission_data.json
+          retention-days: 90
 
       - name: Create PR if score >= 2
         if: steps.read_outputs.outputs.score >= 2 && steps.read_outputs.outputs.has_data == 'true'


### PR DESCRIPTION
New Workflow: Admin Approve Submission (.github/workflows/admin-approve-submission.yml)                 
                                                                                                          
  When a submission is rejected or needs review (like axiom.co), admins can:                              
                                                                                                          
  1. Comment /approve - Approves with original score                                                      
  2. Comment /approve 3 - Approves and overrides score to 3/3                                             
                                                                                                          
  The workflow:                                                                                           
  - Checks if commenter has write/maintain/admin permission                                               
  - Re-evaluates the URL with Claude for metadata                                                         
  - Creates the PR                                                                                        
  - Updates labels (needs-review → approved)                                                              
  - Posts confirmation comment                                                                            
                                                                                                          
  Updated Evaluation Workflow                                                                             
  - Low-scoring submissions now get needs-review label (not auto-closed)                                  
  - Adds a comment explaining how admins can approve: /approve or /approve 3                              
  - Saves submission data as artifact for reference          