### PR TITLE
ogimage Linkedin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,19 +6,22 @@
   <title>Awesome Alt Clouds | Alternative Cloud Providers for Developers</title>
   <meta name="description" content="Discover specialized cloud infrastructure providers built for developers who have specialized requirements and need alternatives to hyperscalers.">
 
-  <!-- Open Graph / Facebook -->
+  <!-- Open Graph / Facebook / LinkedIn -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://datum-cloud.github.io/awesome-alt-clouds/">
   <meta property="og:title" content="Awesome Alt Clouds - When you need something specialized">
   <meta property="og:description" content="A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.">
   <meta property="og:image" content="https://datum-cloud.github.io/awesome-alt-clouds/og-image.png">
+  <meta property="og:image:width" content="1206">
+  <meta property="og:image:height" content="634">
+  <meta property="og:image:type" content="image/png">
 
-  <!-- Twitter -->
-  <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://datum-cloud.github.io/awesome-alt-clouds/">
-  <meta property="twitter:title" content="Awesome Alt Clouds - When you need something specialized">
-  <meta property="twitter:description" content="A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.">
-  <meta property="twitter:image" content="https://datum-cloud.github.io/awesome-alt-clouds/og-image.png">
+  <!-- Twitter / X -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://datum-cloud.github.io/awesome-alt-clouds/">
+  <meta name="twitter:title" content="Awesome Alt Clouds - When you need something specialized">
+  <meta name="twitter:description" content="A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.">
+  <meta name="twitter:image" content="https://datum-cloud.github.io/awesome-alt-clouds/og-image.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
Fix: Added og:image:width & og:image:height
Why: LinkedIn requires these to render OG images reliably. This was almost certainly the root cause.

Fix: Added og:image:type
Why: Best practice for all crawlers to know the image format upfront.

Fix: Changed Twitter tags from property to name
Why: Twitter/X spec requires name attribute, not property. Most crawlers are forgiving, but this ensures correct behavior.