### PR TITLE
Fix mobile UX: add search to sidebar and fix submission flow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -178,6 +178,10 @@
       flex: 0 1 300px;
     }
 
+    .mobile-search-wrapper {
+      display: none;
+    }
+
     .search-input {
       width: 100%;
       padding: 0.5rem 0.875rem 0.5rem 2.25rem;
@@ -888,9 +892,13 @@
         justify-content: space-between;
       }
 
-      .search-box {
-        flex: none;
-        width: 100%;
+      .top-bar .search-box {
+        display: none;
+      }
+
+      .mobile-search-wrapper {
+        display: block;
+        margin-bottom: 0.75rem;
       }
 
       .modal {
@@ -927,6 +935,20 @@
         </div>
         <p class="tagline">When you Need Something .. Specialized!</p>
         <p class="subtitle">Discover specialized infrastructure providers built for developers who think different</p>
+      </div>
+
+      <div class="mobile-search-wrapper">
+        <div class="search-box">
+          <svg class="search-icon" width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+          </svg>
+          <input
+            type="text"
+            class="search-input"
+            id="searchInputMobile"
+            placeholder="Search clouds..."
+          >
+        </div>
       </div>
 
       <div class="categories-section">
@@ -1389,6 +1411,11 @@
     }
 
     document.getElementById('searchInput').addEventListener('input', (e) => {
+      searchTerm = e.target.value;
+      renderClouds();
+    });
+
+    document.getElementById('searchInputMobile').addEventListener('input', (e) => {
       searchTerm = e.target.value;
       renderClouds();
     });

--- a/docs/submit/index.html
+++ b/docs/submit/index.html
@@ -467,14 +467,21 @@ ${notes || 'No additional notes provided.'}
 *This issue was automatically created via the submission form. A GitHub Action will evaluate each service and use AI to generate name, description, and category. Services that pass (2/3 or 3/3 criteria) will be added to a PR.*`;
 
             const issueUrl = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/issues/new?` +
-                new URLSearchParams({
-                    title: issueTitle,
-                    body: issueBody,
-                    labels: 'submission'
-                }).toString();
+                `title=${encodeURIComponent(issueTitle)}&body=${encodeURIComponent(issueBody)}&labels=submission`;
+
+            // Disable button to prevent double-submission and show feedback
+            const btn = document.getElementById('submit-btn');
+            btn.disabled = true;
+            btn.textContent = 'Opening GitHub…';
 
             // Redirect to GitHub to create the issue
             window.location.href = issueUrl;
+
+            // Re-enable in case the user navigates back
+            setTimeout(() => {
+                btn.disabled = false;
+                btn.textContent = 'Submit for Review';
+            }, 4000);
         });
 
         function extractDomain(url) {


### PR DESCRIPTION
- Add mobile-only search input in the sidebar (above categories) so search is visible on first load without scrolling; hide the top-bar search on mobile since it falls below the fold
- Replace URLSearchParams with encodeURIComponent in the submission form so spaces encode as %20 rather than +, fixing blank issue bodies in the GitHub mobile app
- Disable and label the Submit button on click to prevent confusion from multiple taps; re-enable after 4s if the user navigates back