### PR TITLE
fix: put Jina first with X-Return-Format: html for reliable link detection

### DIFF
--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -146,17 +146,16 @@ def fetch_page(url, timeout=15, retries=2):
 
 
 def fetch_page_with_fallback(url, timeout=15, retries=2):
-    """Try requests first, then Jina Reader. Returns (soup, final_url, fetch_method)."""
-    # Stage 1: existing requests-based scraper
-    soup, final_url = fetch_page(url, timeout=timeout, retries=retries)
-    if soup is not None:
-        return soup, final_url, "requests"
-
-    # Stage 2: Jina Reader (handles JS-rendered pages)
+    """Try Jina Reader first (renders JS, bypasses CDN blocks), then requests as fallback.
+    Returns (soup, final_url, fetch_method)."""
+    # Stage 1: Jina Reader with HTML mode — renders JS and handles Cloudflare-protected sites.
+    # X-Return-Format: html ensures we get proper HTML with <a> tags for link detection,
+    # not the default markdown format which breaks find_all('a', href=True).
     jina_url = f"https://r.jina.ai/{url}"
     headers = {
         'User-Agent': 'Mozilla/5.0 (compatible; awesome-alt-clouds-bot/1.0)',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'X-Return-Format': 'html',
     }
     try:
         response = requests.get(jina_url, headers=headers, timeout=timeout, allow_redirects=True)
@@ -166,6 +165,11 @@ def fetch_page_with_fallback(url, timeout=15, retries=2):
             return soup, url, "jina"
     except Exception as e:
         print(f"Jina Reader failed for {url}: {e}")
+
+    # Stage 2: direct requests scraper (cheaper but fails on JS-heavy / CDN-blocked sites)
+    soup, final_url = fetch_page(url, timeout=timeout, retries=retries)
+    if soup is not None:
+        return soup, final_url, "requests"
 
     return None, None, None
 

--- a/tests/test_evaluate_submission.py
+++ b/tests/test_evaluate_submission.py
@@ -75,6 +75,38 @@ class TestFetchPageWithFallback:
 
         assert any('r.jina.ai' in u and 'example.com' in u for u in captured)
 
+    def test_jina_sends_html_format_header(self):
+        """Jina must request HTML (not markdown) so <a> tag link detection works."""
+        captured_kwargs = []
+
+        def side_effect(url, **kwargs):
+            if 'r.jina.ai' in url:
+                captured_kwargs.append(kwargs)
+            raise requests.exceptions.ConnectionError('blocked')
+
+        with patch('requests.get', side_effect=side_effect):
+            ev.fetch_page_with_fallback('https://example.com')
+
+        assert captured_kwargs, "Jina was never called"
+        headers = captured_kwargs[0].get('headers', {})
+        assert headers.get('X-Return-Format') == 'html'
+
+    def test_jina_is_tried_before_requests(self):
+        """Jina must be the first attempt in the cascade."""
+        call_order = []
+
+        def side_effect(url, **kwargs):
+            if 'r.jina.ai' in url:
+                call_order.append('jina')
+            else:
+                call_order.append('requests')
+            raise requests.exceptions.ConnectionError('blocked')
+
+        with patch('requests.get', side_effect=side_effect):
+            ev.fetch_page_with_fallback('https://example.com')
+
+        assert call_order[0] == 'jina', f"Expected jina first, got: {call_order}"
+
 
 # ---------------------------------------------------------------------------
 # evaluate_with_claude_websearch


### PR DESCRIPTION
## Problem

ZeroTier (issue #128) failed validation even after the cascade fix was merged. Root cause was two bugs working together:

1. **GitHub Actions IPs get CDN-blocked** — `requests` returns 403 on many modern cloud sites in CI, so Jina runs as fallback
2. **Jina returns markdown by default** — `find_all('a', href=True)` finds zero links on markdown content, so pricing/signup detection silently fails

Locally the criteria checks pass fine (zerotier.com returns 200 to browser UAs). In CI they fail because requests is blocked and Jina's markdown output breaks link detection.

## Fix

Two targeted changes to `fetch_page_with_fallback`:

- **Add `X-Return-Format: html` header** to Jina requests — Jina now returns rendered HTML with proper `<a>` tags instead of markdown
- **Put Jina first** in the cascade — Jina renders JS-heavy SPAs and bypasses CDN blocks; requests becomes the cheaper fallback

New cascade: **Jina (html mode) → requests → Claude web search**

Verified locally: Jina with HTML mode finds both `zerotier.com/pricing/` and the "Start Free" signup link that previously went undetected.

## Test Plan
- [ ] 21 tests pass (`pytest tests/test_evaluate_submission.py -v`)
- [ ] Two new tests added: `test_jina_sends_html_format_header`, `test_jina_is_tried_before_requests`
- [ ] Re-run evaluation on zerotier.com issue to confirm 3/3 score