### PR TITLE
Add Skyhook to PaaS & Application Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ AI-powered code editors, IDEs, no-code/low-code builders, and full-stack app gen
 
 Platform-as-a-service and managed hosting providers for deploying and scaling web applications, APIs, and services.
 
+* 🟢 [Skyhook](https://skyhook.io/) - PaaS for deploying and managing Kubernetes clusters and workloads with GitOps support, preview environments, and AI assistance.
+
 ## Developer Tooling & CI/CD
 
 Build systems, artifact registries, CI/CD pipelines, cloud dev environments, testing frameworks, feature flags, and developer productivity tools.


### PR DESCRIPTION
## Summary
- Add Skyhook.io to the PaaS & Application Hosting category
- Skyhook is a PaaS for deploying and managing Kubernetes clusters and workloads

## Verification
- Public pricing: https://skyhook.io/pricing
- Self-service signup: https://app.skyhook.io
- Status page: https://skyhook.io/status