### PR TITLE
Fix category misplacements and SPA submission validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,30 @@ Alt Clouds provide value "as a service" directly on top of infrastructure. They 
 
 ## Contents
 
-* [Criteria](#criteria)
-* [Infrastructure Clouds](#infrastructure-clouds)
-* [GPU & AI Compute Clouds](#gpu--ai-compute-clouds)
-* [Security, Compliance & Sovereignty Clouds](#security-compliance--sovereignty-clouds)
-* [Unikernels & WebAssembly](#unikernels--webassembly)
-* [Databases & Storage](#databases--storage)
-* [Analytics & Data Warehousing](#analytics--data-warehousing)
-* [Observability & Monitoring](#observability--monitoring)
-* [Data Integration & ETL](#data-integration--etl)
-* [Workflow & Operations Clouds](#workflow--operations-clouds)
-* [Network & Connectivity Clouds](#network--connectivity-clouds)
-* [AI Inference & Model APIs](#ai-inference--model-apis)
 * [AI Assistants & Copilots](#ai-assistants--copilots)
 * [AI Coding & App Generation](#ai-coding--app-generation)
-* [PaaS & Application Hosting](#paas--application-hosting)
-* [Developer Tooling & CI/CD](#developer-tooling--cicd)
+* [AI Inference & Model APIs](#ai-inference--model-apis)
+* [Analytics & Data Warehousing](#analytics--data-warehousing)
 * [Authorization, Identity & Fraud](#authorization-identity--fraud)
-* [Monetization & Billing Clouds](#monetization--billing-clouds)
-* [Customer, Marketing & eCommerce](#customer-marketing--ecommerce)
-* [Communications, IoT & Media](#communications-iot--media)
-* [Decentralized & Web3 Compute](#decentralized--web3-compute)
-* [Source Code Control](#source-code-control)
 * [Cloud Adjacent & Infrastructure Tooling](#cloud-adjacent--infrastructure-tooling)
+* [Communications, IoT & Media](#communications-iot--media)
+* [Criteria](#criteria)
+* [Customer, Marketing & eCommerce](#customer-marketing--ecommerce)
+* [Data Integration & ETL](#data-integration--etl)
+* [Databases & Storage](#databases--storage)
+* [Decentralized & Web3 Compute](#decentralized--web3-compute)
+* [Developer Tooling & CI/CD](#developer-tooling--cicd)
 * [Emerging & Unverified Providers](#emerging--unverified-providers)
+* [GPU & AI Compute Clouds](#gpu--ai-compute-clouds)
+* [Infrastructure Clouds](#infrastructure-clouds)
+* [Monetization & Billing Clouds](#monetization--billing-clouds)
+* [Network & Connectivity Clouds](#network--connectivity-clouds)
+* [Observability & Monitoring](#observability--monitoring)
+* [PaaS & Application Hosting](#paas--application-hosting)
+* [Security, Compliance & Sovereignty Clouds](#security-compliance--sovereignty-clouds)
+* [Source Code Control](#source-code-control)
+* [Unikernels & WebAssembly](#unikernels--webassembly)
+* [Workflow & Operations Clouds](#workflow--operations-clouds)
 
 ## Criteria
 
@@ -45,107 +45,109 @@ Services in this list are evaluated against 3 criteria:
 
 > Services meeting at least 2 of 3 criteria are included. Scoring is based on manual evaluation of well-known services and automated checks for new submissions.
 
-
 ## Infrastructure Clouds
 
 The original "alt clouds" providing everything from virtualized and bare metal compute to GPU's, storage, and inference services.
 
-* 🟢 [Aethir](https://aethir.com) - Provides secure, cost-effective access to enterprise-grade GPUs worldwide through a distributed cloud compute infrastructure.
-* 🟢 [Anyscale](https://www.anyscale.com/) - Distributed computing platform built on Ray for scaling AI and Python apps.
-* 🟢 [api.video](https://api.video/) - Developer-first video API for encoding, hosting, streaming.
 * 🟢 [Arcade](https://www.arcade.dev/) - Cloud service provider.
 * 🟢 [Atlantic.net](https://www.atlantic.net/) - Experienced hosting company offering a variety of compute and GPU infrastructure services.
 * 🟢 [Axiom](https://axiom.co/) - Cloud service provider.
-* 🟢 [Banana.dev](https://www.banana.dev/) - Serverless GPU platform for ML model inference with pay-per-millisecond pricing.
-* 🟢 [Baseten](https://www.baseten.co/) - Enables fast, reliable model inference with flexible deployment options, including self-hosted and hybrid.
 * 🟢 [Beam](https://www.beam.cloud) - Cloud infrastructure specifically built for high-performance applications and developer happiness.
 * 🟡 [Browser-Use](https://browser-use.com/) - Cloud service provider.
-* 🟢 [Browserbase](https://www.browserbase.com/) - A platform for running headless browsers for interact with websites via automation.
-* 🟢 [Cerebrium](https://www.cerebrium.ai/) - Serverless GPU infrastructure for deploying ML models with auto-scaling.
 * 🟢 [Civo](https://www.civo.com) - Provides cloud services with a focus on simplicity and developer experience.
-* 🟡 [CoreWeave](https://www.coreweave.com/) - A cloud platform optimized for AI, offering high-performance GPU compute and managed services.
-* 🟢 [Crusoe Energy](https://crusoecloud.com/) - Energy-efficient GPU computing using stranded and renewable energy sources.
-* 🟢 [Cudo Compute](https://www.cudocompute.com/) - Offers decentralized cloud computing with GPU support for AI applications.
 * 🟢 [Cycle.io](https://cycle.io/) - Provides a container orchestration platform for deploying applications.
-* 🟢 [Datacrunch.io](https://datacrunch.io/) - Provides affordable GPU cloud services for AI training and inference.
 * 🟢 [DataPacket](https://www.datapacket.com/) - Offers high-performance infrastructure for bandwidth-intensive applications.
 * 🟢 [Digital Ocean](https://www.digitalocean.com/) - Provides cloud computing services with simplicity and scalability.
 * 🟢 [E2E Cloud](https://www.e2enetworks.com/) - Offers cloud infrastructure with GPU instances for AI and machine learning.
 * 🟢 [Empromptu](https://empromptu.ai) - Cloud service provider.
 * 🟢 [exe.dev](https://exe.dev/) - Modern VM hosting with sub-second starts and persistent disks. Built for AI coding agents with built-in HTTPS/auth and sharing.
-* 🟢 [Fal.ai](https://fal.ai/) - Provides serverless GPU inference for AI models with instant deployment.
 * 🟢 [Firmus](https://firmus.co/) - Cloud service provider.
-* 🟢 [FluidStack](https://www.fluidstack.io/) - Offers decentralized GPU cloud computing for AI and rendering workloads.
-* 🟢 [FriendliAI](https://friendli.ai/) - Fast AI inference platform with 2-3x speed boost. Deploy 490K+ models instantly. Serverless & dedicated GPU options. 99.99% SLA.
 * 🟡 [Freestyle](https://freestyle.sh) - Infrastructure for managing and executing AI-generated code through sandboxed VMs, Git repositories, and deployment services.
 * 🟢 [Gcore](https://gcore.com/) - Delivers edge and cloud services with global infrastructure.
-* 🟢 [Genesis Cloud](https://www.genesiscloud.com/pricing) - Offers sustainable, high-performance GPU cloud computing for AI workloads.
-* 🟢 [GMI Cloud](https://www.gmicloud.ai/) - Provides GPU cloud services optimized for AI and deep learning tasks.
-* 🟡 [GPU CLI](https://gpu-cli.sh) - Provides command-line access to remote cloud GPUs with auto-stop functionality, instant connection, and automatic result syncing for ML training and inference workloads.
 * 🟡 [Hetzner](https://www.hetzner.com/) - Provides dedicated servers and cloud services in Europe.
 * 🟢 [Hivelocity](https://www.hivelocity.net/) - Experienced provider of VPS and bare metal solutions.
-* 🟢 [HydraHost](https://hydrahost.com/) - Affordable GPU compute focused on researchers and indie developers.
-* 🟢 [Hyperbolic](https://hyperbolic.xyz/) - Offers scalable GPU compute for AI applications with a focus on performance and cost-efficiency.
-* 🟢 [Hyperstack](https://www.hyperstack.cloud/) - Cloud GPU and AI platform for building, training, and deploying custom AI models.
 * 🟢 [IONOS Cloud](https://cloud.ionos.com/) - Cloud infrastructure with a focus on public, bare metal, and managed Kubernetes solutions.
 * 🟡 [Kernel](https://www.kernel.sh/) - Cloud service provider.
-* 🟢 [Lambda Labs](https://lambda.ai/) - Delivers on-demand access to NVIDIA GPUs for AI training and inference.
 * 🟢 [Latitude.sh](https://www.latitude.sh/) - Provides global bare metal servers for developers.
-* 🟢 [LeaderGPU](https://www.leadergpu.com/) - Provides high-performance GPU servers for rent, optimized for AI tasks.
 * 🟢 [LeaseWeb](https://www.leaseweb.com/) - Full service hosting provider with a background in dedicated and managed servers.
 * 🟢 [Linode](https://www.linode.com/) - Provides cloud computing services designed for developers with straightforward pricing.
 * 🟢 [Lyceum](https://lyceum.technology/) - EU built and operated GPU cloud for developers and AI teams.
-* 🟢 [Modal](https://modal.com/) - A serverless platform for AI and data teams to run compute-intensive applications without managing infrastructure.
 * 🟡 [Namespace](https://namespace.so/) - Cloud service provider.
-* 🟢 [Nebius](https://nebius.com/) - Provides AI-centric cloud infrastructure with large-scale GPU clusters and managed services.
-* 🟢 [NeevCloud](https://www.neevcloud.com/) - India-based GPU cloud offering secure, scalable AI compute.
 * 🟢 [NetActuate](https://netactuate.com/) - Provides hybrid cloud and edge computing solutions with a global network.
-* 🟢 [NextGen Cloud](https://www.nextgencloud.com/) - Delivers sustainable, high-performance cloud infrastructure for AI workloads.
 * 🟢 [Openmetal.io](https://openmetal.io/) - Delivers on-demand private cloud infrastructure based on OpenStack.
 * 🟡 [OVH Cloud](https://us.ovhcloud.com/) - Global cloud provider offering compute, storage, and network solutions.
-* 🟡 [Paperspace](https://www.paperspace.com/) - Cloud computing with GPU support for AI development and deployment. Now owned by DigitalOcean.
-* 🟢 [Parasail](https://parasail.ai/) - Serverless GPU platform to run custom AI models easily.
 * 🟢 [QBO](https://qbo.io/) - GPU Cloud at the Edge & Beyond - Delivering high performance, streamlined infrastructure, and flexible AI/ML deployment.
 * 🟢 [Rackdog](https://rackdog.com/) - Cloud service provider.
 * 🟢 [Rackspace](https://www.rackspace.com/) - Provides hybrid cloud and managed hosting services.
-* 🟢 [Runpod](https://www.runpod.io/) - Provides customizable GPU containers and secure cloud compute environments.
 * 🟢 [Salad](https://salad.com/) - A platform for leveraging latent consumer compute resources to power workloads.
 * 🟢 [Scaleway](https://www.scaleway.com/) - European cloud provider with a wide range of services including servers, storage, and AI tools.
 * 🟢 [Seeweb](https://www.seeweb.it/) - Italian cloud infrastructure provider offering compute, storage, and CDN.
 * 🟡 [Sent](https://www.sent.dm/) - Cloud service provider.
 * 🟢 [Servers.com](https://www.servers.com/) - Global bare metal and private cloud platform supporting AI/ML compute.
-* 🟢 [Shadeform](https://shadeform.com/) - GPU compute provider with a focus on low-cost AI infrastructure.
-* 🟡 [SharonAI](https://sharonai.com/en/) - Provides AI-powered solutions and services for business automation and intelligent decision-making processes.
 * 🟢 [Spheron Network](https://www.spheron.network/) - Decentralized GPU/CPU network for AI and Web3 with 44,000+ nodes across 170+ locations.
 * 🟡 [Sprites](https://sprites.dev/) - Provides hardware-isolated, stateful Linux sandbox environments with checkpoint and restore capabilities for running arbitrary code with persistent storage and HTTP access.
 * 🟢 [Sustainable Metal Cloud](https://smc.co/) - Green-focused GPU cloud with a sustainability-first infrastructure model.
-* 🟢 [TensorDock](https://tensordock.com/) - Affordable, usage-based GPU cloud platform for model training.
-* 🟢 [TensorWave](https://tensorwave.com/) - An AI cloud focused on AMD technology including MI325X and MI300X accelerators.
-* 🟢 [Thunder Compute](https://www.thundercompute.com/) - Provides on-demand GPU instances with RTX A6000, A100, and H100 options at competitive pricing, featuring VS Code integration and one-click deployment for ML development.
-* 🟢 [Turboscale](https://www.turboscale.ai/) - AI-native cloud infrastructure for fine-tuning and inference.
-* 🟢 [Upsun](https://upsun.com/) - An application hosting platform from the team at Platform.sh.
-* 🟢 [Vast.ai](https://vast.ai/) - Marketplace for buying and selling GPU compute capacity at competitive rates.
-* 🟢 [Voltage Park](https://www.voltagepark.com/) - AI cloud with 24,000 NVIDIA H100 GPUs and InfiniBand clusters for large-scale training.
 * 🟢 [Vultr](https://www.vultr.com/) - Full services cloud and hosting provider with an expanding range of solutions globally.
-* 🟢 [Warp](https://www.warp.dev/) - Cloud service provider.
 
 ## GPU & AI Compute Clouds
 
 Specialized providers offering on-demand GPU clusters, serverless inference, and high-performance compute optimized for AI training and model serving.
 
+* 🟢 [Aethir](https://aethir.com) - Provides secure, cost-effective access to enterprise-grade GPUs worldwide through a distributed cloud compute infrastructure.
+* 🟢 [Anyscale](https://www.anyscale.com/) - Distributed computing platform built on Ray for scaling AI and Python apps.
+* 🟢 [Banana.dev](https://www.banana.dev/) - Serverless GPU platform for ML model inference with pay-per-millisecond pricing.
+* 🟢 [Baseten](https://www.baseten.co/) - Enables fast, reliable model inference with flexible deployment options, including self-hosted and hybrid.
+* 🟢 [Cerebrium](https://www.cerebrium.ai/) - Serverless GPU infrastructure for deploying ML models with auto-scaling.
+* 🟡 [CoreWeave](https://www.coreweave.com/) - A cloud platform optimized for AI, offering high-performance GPU compute and managed services.
+* 🟢 [Crusoe Energy](https://crusoecloud.com/) - Energy-efficient GPU computing using stranded and renewable energy sources.
+* 🟢 [Cudo Compute](https://www.cudocompute.com/) - Offers decentralized cloud computing with GPU support for AI applications.
+* 🟢 [Datacrunch.io](https://datacrunch.io/) - Provides affordable GPU cloud services for AI training and inference.
+* 🟢 [Fal.ai](https://fal.ai/) - Provides serverless GPU inference for AI models with instant deployment.
+* 🟢 [FluidStack](https://www.fluidstack.io/) - Offers decentralized GPU cloud computing for AI and rendering workloads.
+* 🟢 [FriendliAI](https://friendli.ai/) - Fast AI inference platform with 2-3x speed boost. Deploy 490K+ models instantly. Serverless & dedicated GPU options. 99.99% SLA.
+* 🟢 [Genesis Cloud](https://www.genesiscloud.com/pricing) - Offers sustainable, high-performance GPU cloud computing for AI workloads.
+* 🟢 [GMI Cloud](https://www.gmicloud.ai/) - Provides GPU cloud services optimized for AI and deep learning tasks.
+* 🟡 [GPU CLI](https://gpu-cli.sh) - Provides command-line access to remote cloud GPUs with auto-stop functionality, instant connection, and automatic result syncing for ML training and inference workloads.
+* 🟢 [HydraHost](https://hydrahost.com/) - Affordable GPU compute focused on researchers and indie developers.
+* 🟢 [Hyperbolic](https://hyperbolic.xyz/) - Offers scalable GPU compute for AI applications with a focus on performance and cost-efficiency.
+* 🟢 [Hyperstack](https://www.hyperstack.cloud/) - Cloud GPU and AI platform for building, training, and deploying custom AI models.
+* 🟢 [Lambda Labs](https://lambda.ai/) - Delivers on-demand access to NVIDIA GPUs for AI training and inference.
+* 🟢 [LeaderGPU](https://www.leadergpu.com/) - Provides high-performance GPU servers for rent, optimized for AI tasks.
+* 🟢 [Lightning.ai](https://lightning.ai/) - Build, train, and deploy AI models with powerful tools and scalable infrastructure.
+* 🟢 [Modal](https://modal.com/) - A serverless platform for AI and data teams to run compute-intensive applications without managing infrastructure.
+* 🟢 [Nebius](https://nebius.com/) - Provides AI-centric cloud infrastructure with large-scale GPU clusters and managed services.
+* 🟢 [NeevCloud](https://www.neevcloud.com/) - India-based GPU cloud offering secure, scalable AI compute.
+* 🟢 [NextGen Cloud](https://www.nextgencloud.com/) - Delivers sustainable, high-performance cloud infrastructure for AI workloads.
+* 🟡 [Paperspace](https://www.paperspace.com/) - Cloud computing with GPU support for AI development and deployment. Now owned by DigitalOcean.
+* 🟢 [Parasail](https://parasail.ai/) - Serverless GPU platform to run custom AI models easily.
+* 🟢 [Runpod](https://www.runpod.io/) - Provides customizable GPU containers and secure cloud compute environments.
+* 🟢 [Shadeform](https://shadeform.com/) - GPU compute provider with a focus on low-cost AI infrastructure.
+* 🟢 [TensorDock](https://tensordock.com/) - Affordable, usage-based GPU cloud platform for model training.
+* 🟢 [TensorWave](https://tensorwave.com/) - An AI cloud focused on AMD technology including MI325X and MI300X accelerators.
+* 🟢 [Thunder Compute](https://www.thundercompute.com/) - Provides on-demand GPU instances with RTX A6000, A100, and H100 options at competitive pricing, featuring VS Code integration and one-click deployment for ML development.
+* 🟢 [Turboscale](https://www.turboscale.ai/) - AI-native cloud infrastructure for fine-tuning and inference.
+* 🟢 [Vast.ai](https://vast.ai/) - Marketplace for buying and selling GPU compute capacity at competitive rates.
+* 🟢 [Voltage Park](https://www.voltagepark.com/) - AI cloud with 24,000 NVIDIA H100 GPUs and InfiniBand clusters for large-scale training.
+
 ## Security, Compliance & Sovereignty Clouds
 
 Cloud platforms designed to ensure data residency, regulatory compliance, and national control over infrastructure—often tailored for governments, public sector, or regulated industries.
 
+* 🟢 [CrowdStrike](https://www.crowdstrike.com/) - A cloud-native cybersecurity platform that provides endpoint protection, threat intelligence, and incident response powered by AI.
+* 🟢 [Fortinet](https://www.fortinet.com/) - Provides integrated cybersecurity solutions including next-gen firewalls, secure SD-WAN, and endpoint protection.
 * 🟢 [FPT Vietnam](https://fptsoftware.com/newsroom/news-and-press-releases/press-release/fpt-to-shape-the-future-of-ai-and-cloud-on-a-global-scale-in-collaboration-with-nvidia) - Investing $200 million to build an AI factory serving as a sovereign cloud, featuring NVIDIA's latest technologies to bolster Vietnam's digital sovereignty.
 * 🟢 [GMO GPU Cloud](https://www.gmo.jp/en/news/article/797/) - Offers GPU cloud services in Japan, providing scalable AI computing with NVIDIA's latest GPUs, ensuring data residency and compliance.
 * 🟢 [Jottacloud](https://jottacloud.com/en/) - Norwegian cloud storage service operating under Norway's strict privacy laws, providing an alternative to US-based cloud services with guaranteed data residency.
 * 🟢 [metalstack.cloud](https://www.metalstack.cloud/) - Open-source managed Kubernetes on bare metal in Germany with physical tenant isolation and GDPR compliance.
+* 🟢 [Netskope](https://www.netskope.com/) - A cloud-native security platform that protects users, apps, and data with visibility and control across SaaS, IaaS, and the web.
 * 🟢 [Ola Krutrim](https://www.olakrutrim.com/) - Developing India's first sovereign AI cloud, offering scalable GPU-accelerated services and domestically designed AI chips to empower AI workloads.
+* 🟢 [Operant](https://operant.ai/) - Provides runtime protection for cloud-native applications using graph-based detection and real-time observability.
 * 🟢 [Reliance](https://www.ril.com/) - Indian conglomerate with plans to develop sovereign cloud infrastructure to support the country's digital initiatives and data localization requirements.
 * 🟢 [Sakura Internet](https://www.sakura.ad.jp/corporate/en/information/equinix-and-sakura-internet-launch-strategic-partnership/) - Japanese cloud provider partnering with Equinix to offer GPU-based cloud services, supporting the growing demand for AI and ensuring data sovereignty.
 * 🟢 [T-Systems](https://www.t-systems.com/) - German IT services and consulting company providing sovereign cloud solutions to ensure data protection and compliance with European regulations.
+* 🟢 [Wiz](https://www.wiz.io/) - A cloud security platform that gives full-stack visibility into cloud infrastructure and prioritizes risk across workloads, containers, and identities.
 * 🟢 [Yotta](https://yotta.com/blog-need-of-sovereign-cloud-in-india/) - Indian data center and cloud services provider focusing on security, compliance, and innovation.
+* 🟢 [Zscaler](https://www.zscaler.com/) - Zero trust SASE platform with AI-driven cybersecurity and cloud protection.
 
 ## Unikernels & WebAssembly
 
@@ -154,105 +156,109 @@ Platforms leveraging unikernel and WebAssembly technologies for lightweight, sec
 * 🟢 [Cosmonic](https://cosmonic.com/) - A distributed compute mesh built on CNCF's wasmCloud, enabling secure, declarative deployments of WebAssembly applications across diverse environments.
 * 🟢 [KraftCloud](https://kraft.cloud/) - A next-generation cloud platform powered by unikernels, offering millisecond-scale operations and high-density deployments for efficient computing.
 * 🟢 [NanoVMs](https://nanovms.com/) - Provides a unikernel platform that allows deploying applications as secure, isolated virtual machines, enhancing performance and security.
-* 🟢 [Puter](https://puter.com/) - A privacy-first personal cloud that houses all your files, apps, and games in one secure place, accessible from anywhere at any time.
-* 🟢 [SingleStore](https://www.singlestore.com/) - Real-time database combining transactions and analytics with vector search capabilities.
 * 🟢 [Wasmer](https://wasmer.io/) - Offers a universal WebAssembly runtime that enables running applications safely and efficiently across various platforms, from desktop to cloud and edge.
 
 ## Databases & Storage
 
 Managed databases, object storage, caching, and search engines — relational, NoSQL, vector, time-series, and beyond.
 
-* 🟢 [Airbyte](https://airbyte.com/) - Open-source data integration platform with 600+ connectors and CDK for custom integrations.
-* 🟢 [Algolia](https://www.algolia.com/) - AI-powered search and discovery API with NeuralSearch and semantic understanding for <50ms search speed.
-* 🟡 [Arroyo](https://arroyo.dev) - Provides cloud-native stream processing engine built in Rust that enables real-time data transformation, filtering, aggregation, and joins using SQL with sub-second results.
-* 🟢 [Storadera](https://storaderacom.com/) - European S3 compatible cloud storage with predictable pricing, no egress fees, and multi-region infrastructure for backup, AI, and cloud workloads.
 * 🟢 [Aiven](https://aiven.io/) - Offers managed open-source data infrastructure, including databases and messaging systems, on all major clouds.
-* 🟢 [Amplitude](https://amplitude.com/) - Provides product analytics to help teams understand user behavior and build better products.
-* 🟢 [BetterStack](https://betterstack.com/) - Combines monitoring, logging, and incident management into a single platform for developers.
+* 🟢 [Algolia](https://www.algolia.com/) - AI-powered search and discovery API with NeuralSearch and semantic understanding for <50ms search speed.
 * 🟢 [CedarDB](https://cedardb.com/) - Modern columnar database for real-time analytics.
-* 🟢 [Checkly](https://www.checklyhq.com/) - Application reliability platform unifying testing, monitoring, observability, and incident management with Playwright-based synthetic monitoring.
-* 🟢 [Chronosphere](https://chronosphere.io/) - Delivers a scalable observability platform designed for cloud-native environments, helping teams control costs and improve reliability.
-* 🟢 [ClickHouse](https://clickhouse.com/) - An open-source, column-oriented OLAP database management system for real-time analytics using SQL queries.
 * 🟢 [Cockroach Labs](https://www.cockroachlabs.com/) - Develops CockroachDB, a distributed SQL database for building global, scalable cloud services.
 * 🟢 [Convex](https://www.convex.dev/) - Reactive backend platform with real-time database and serverless functions.
-* 🟢 [Comet](https://www.comet.com/) - AI observability and evaluation platform with tracing, human annotation, and automated evaluation for LLM applications.
-* 🟢 [Coralogix](https://coralogix.com/) - Ingest all your data, store it indefinitely on your cloud, and query across all types with a unified syntax.
 * 🟢 [Couchbase](https://www.couchbase.com/) - Offers a distributed NoSQL cloud database for mission-critical applications.
-* 🟢 [Databricks](https://www.databricks.com/) - Provides a unified analytics platform for big data and AI, built on Apache Spark.
-* 🟢 [Datadog](https://www.datadoghq.com/) - A monitoring and security platform for cloud applications.
-* 🟢 [dbt Labs](https://www.getdbt.com/) - Empowers data practitioners to transform data in their warehouses by developing, testing, and documenting analytics code.
 * 🟢 [Diffbot](https://www.diffbot.com/) - Uses AI to build a knowledge graph of the web, enabling businesses to extract and understand web data.
 * 🟢 [Ditto](https://www.ditto.com/) - An edge-native, mobile database that thrives on mobile and edge devices.
-* 🟢 [Domo](https://www.domo.com/) - Provides a cloud-based platform for business intelligence and data visualization.
-* 🟢 [DuckDB](https://duckdb.org/) - An in-process SQL OLAP database management system designed for fast analytical queries.
-* 🟢 [Dynatrace](https://www.dynatrace.com/) - Offers a unified observability and security platform powered by AI, providing analytics and automation for multicloud environments.
-* 🟢 [Elastic](https://www.elastic.co/) - Provides search-powered solutions for observability, security, and enterprise search.
-* 🟢 [Fathom](https://usefathom.com/) - Privacy-focused web analytics platform offering real-time insights without cookies or invasive tracking.
-* 🟢 [Firebolt](https://www.firebolt.io/) - Delivers a cloud data warehouse designed for high-performance analytics.
-* 🟢 [Fivetran](https://www.fivetran.com/) - Automated data integration platform with 300+ connectors and zero-maintenance ETL pipelines.
-* 🟢 [FullStory](https://www.fullstory.com/) - Offers digital experience analytics to understand and improve user interactions.
 * 🟢 [Gel](https://www.geldata.com/) - Next-generation graph-relational database with modern query language.
-* 🟢 [Grafana](https://grafana.com/) - An open-source platform for monitoring and observability, enabling visualization of metrics, logs, and traces.
-* 🟢 [groundcover](https://www.groundcover.com/) - eBPF-based observability platform with BYOC architecture for logs, metrics, and traces.
 * 🟢 [Hasura](https://hasura.io/) - Instantly generates GraphQL APIs over new or existing PostgresSQL databases.
-* 🟢 [Heap](https://heap.io/) - Automatically captures user interactions to provide insights into user behavior without manual tracking.
-* 🟢 [Honeycomb](https://www.honeycomb.io/) - An observability platform that helps engineering teams understand, debug, and improve complex systems.
-* 🟢 [Highlight](https://highlight.io/) - Open-source fullstack monitoring platform with session replay, error monitoring, logging, and traces.
 * 🟢 [Hydrolix](https://hydrolix.io/) - A streaming data lake that ingests and processes high-volume, high-cardinality log data in real time, providing scalable storage and query capabilities with cost-efficient resource utilization.
 * 🟢 [InfluxData](https://www.influxdata.com/) - Purpose-built time-series database for cloud, on-premises, and edge deployments.
-* 🟢 [Kentik](https://www.kentik.com/) - Provides network observability solutions for performance monitoring and security.
-* 🟢 [LogRocket](https://logrocket.com/) - Replays user sessions to help developers understand and fix issues faster.
-* 🟢 [Logz.io](https://logz.io/) - Offers an open-source observability platform for monitoring, troubleshooting, and securing applications.
 * 🟢 [Materialize](https://materialize.com/) - Streaming SQL database for real-time data transformation and analytics.
 * 🟢 [Meilisearch](https://www.meilisearch.com/) - Rust-based open-source search engine with hybrid search capabilities and typo-tolerant fast search.
-* 🟢 [Mezmo](https://www.mezmo.com/) - Provides a central observability platform to control, enrich, and correlate machine data for faster business decisions.
-* 🟢 [Mixpanel](https://mixpanel.com/) - Delivers product analytics to help teams build better products through data-driven decisions.
 * 🟢 [Momento](https://www.gomomento.com/) - Serverless caching with instant scaling, no cluster management, compatible with Redis clients and Memcached protocols.
 * 🟢 [MongoDB](https://www.mongodb.com/) - Offers a general-purpose, document-based database designed for modern application development.
-* 🟢 [MotherDuck](https://motherduck.com/) - Serverless analytics platform powered by DuckDB with cloud collaboration.
 * 🟢 [Neo4j](https://neo4j.com/) - A graph database platform for connected data applications.
 * 🟢 [Neon](https://neon.tech/) - Provides a serverless PostgresSQL with autoscaling, branching, and bottomless storage.
-* 🟢 [New Relic](https://newrelic.com/) - An observability platform that unifies metrics, events, logs, and traces for full-stack monitoring.
-* 🟢 [OpenStatus](https://www.openstatus.dev/) - Open-source status page and monitoring platform for tracking API and website uptime worldwide.
 * 🟢 [Planetscale](https://planetscale.com/) - A serverless database platform built on Vitess, offering scalability and reliability for MySQL databases.
-* 🟢 [Plausible](https://plausible.io/) - Lightweight, privacy-focused web analytics platform without cookies, offering essential metrics in an intuitive dashboard.
-* 🟢 [PostHog](https://posthog.com/) - An open-source product analytics platform that can be deployed on-premises.
 * 🟢 [Prisma](https://www.prisma.io/) - Provides a next-generation ORM for Node.js and TypeScript.
 * 🟢 [QuestDB](https://questdb.com/) - Open-source time-series database with ultra-low latency and SQL support.
 * 🟢 [ReadySet](https://readyset.io/) - SQL caching engine that sits between app and database for performance.
-* 🟢 [Redpanda](https://www.redpanda.com/) - Kafka-compatible streaming data platform with built-in identity controls and policy enforcement for AI workloads.
 * 🟢 [Redis](https://redis.io/) - An in-memory data structure store used as a database, cache, and message broker.
-* 🟢 [Rivery](https://rivery.io/) - No-code data integration platform with visual workflows and 150+ connectors with built-in transformations.
-* 🟢 [Sentry](https://sentry.io/) - Application monitoring platform for error tracking, performance monitoring, and session replay to identify and resolve code issues.
-* 🟢 [Snowflake](https://www.snowflake.com/en/) - A cloud data platform offering data warehousing, data lakes, and data sharing capabilities.
-* 🟢 [Splunk](https://www.splunk.com/) - Provides a platform for searching, monitoring, and analyzing machine-generated big data.
+* 🟢 [SingleStore](https://www.singlestore.com/) - Real-time database combining transactions and analytics with vector search capabilities.
 * 🟢 [Steampipe](https://steampipe.io/) - Query APIs and cloud services using SQL with instant data access.
 * 🟢 [Storadera](https://storadera.com) - European S3 compatible cloud storage with predictable pricing, no egress fees, and multi-region infrastructure for backup, AI, and cloud workloads.
-* 🟢 [Sumo Logic](https://www.sumologic.com/) - Offers cloud-native machine data analytics for real-time insights into operations and security.
 * 🟢 [Supabase](https://supabase.com/) - An open-source Firebase alternative that provides a backend-as-a-service.
 * 🟢 [SurrealDB](https://surrealdb.com/) - Multi-model database for web, mobile, serverless, and cloud applications.
-* 🟢 [Teradata](https://www.teradata.com/) - Specializing in providing solutions for data warehousing, analytics, and big data analytics.
 * 🟢 [TigerData](https://www.tigerdata.com/) - PostgreSQL-based time-series database with compression and continuous aggregates.
 * 🟢 [Tigris](https://www.tigrisdata.com/) - A globally distributed S3-compatible object storage service that enables developers to store and access any amount of data.
-* 🟢 [Tinybird](https://www.tinybird.co/) - Real-time data platform for building instant APIs over streaming and batch data.
 * 🟡 [Turso](https://turso.tech/) - Distributed SQLite database with global edge replication.
 * 🟢 [Typesense](https://typesense.org/) - Open-source typo-tolerant search engine with <50ms speed. Self-hosted or cloud options available.
 * 🟢 [Upstash](https://upstash.com/) - Serverless Redis and Kafka with per-request pricing, global replication, and REST API for edge computing workloads.
 * 🟢 [Wasabi](https://wasabi.com/) - A S3-compatible object storage service for use with AI, content delivery, backup, and archiving workloads with no egress or API fees.
-* 🟢 [Weights & Biases](https://wandb.ai/) - AI developer platform for experiment tracking, model management, evaluation, and observability for ML and LLM applications.
 * 🟢 [Xata](https://xata.io/) - Serverless database platform with built-in search and analytics.
 
 ## Analytics & Data Warehousing
 
 Cloud data warehouses, OLAP engines, product analytics, and BI platforms for querying and understanding data at scale.
 
+* 🟢 [Amplitude](https://amplitude.com/) - Provides product analytics to help teams understand user behavior and build better products.
+* 🟢 [ClickHouse](https://clickhouse.com/) - An open-source, column-oriented OLAP database management system for real-time analytics using SQL queries.
+* 🟢 [Databricks](https://www.databricks.com/) - Provides a unified analytics platform for big data and AI, built on Apache Spark.
+* 🟢 [Domo](https://www.domo.com/) - Provides a cloud-based platform for business intelligence and data visualization.
+* 🟢 [DuckDB](https://duckdb.org/) - An in-process SQL OLAP database management system designed for fast analytical queries.
+* 🟢 [Fathom](https://usefathom.com/) - Privacy-focused web analytics platform offering real-time insights without cookies or invasive tracking.
+* 🟢 [Firebolt](https://www.firebolt.io/) - Delivers a cloud data warehouse designed for high-performance analytics.
+* 🟢 [FullStory](https://www.fullstory.com/) - Offers digital experience analytics to understand and improve user interactions.
+* 🟢 [Heap](https://heap.io/) - Automatically captures user interactions to provide insights into user behavior without manual tracking.
+* 🟢 [Mixpanel](https://mixpanel.com/) - Delivers product analytics to help teams build better products through data-driven decisions.
+* 🟢 [MotherDuck](https://motherduck.com/) - Serverless analytics platform powered by DuckDB with cloud collaboration.
+* 🟢 [Plausible](https://plausible.io/) - Lightweight, privacy-focused web analytics platform without cookies, offering essential metrics in an intuitive dashboard.
+* 🟢 [PostHog](https://posthog.com/) - An open-source product analytics platform that can be deployed on-premises.
+* 🟢 [Snowflake](https://www.snowflake.com/en/) - A cloud data platform offering data warehousing, data lakes, and data sharing capabilities.
+* 🟢 [Teradata](https://www.teradata.com/) - Specializing in providing solutions for data warehousing, analytics, and big data analytics.
+* 🟢 [Tinybird](https://www.tinybird.co/) - Real-time data platform for building instant APIs over streaming and batch data.
+
 ## Observability & Monitoring
 
 Logging, metrics, tracing, error tracking, uptime monitoring, and session replay tools for understanding system and application behavior.
 
+* 🟢 [BetterStack](https://betterstack.com/) - Combines monitoring, logging, and incident management into a single platform for developers.
+* 🟢 [Checkly](https://www.checklyhq.com/) - Application reliability platform unifying testing, monitoring, observability, and incident management with Playwright-based synthetic monitoring.
+* 🟢 [Chronosphere](https://chronosphere.io/) - Delivers a scalable observability platform designed for cloud-native environments, helping teams control costs and improve reliability.
+* 🟢 [Comet](https://www.comet.com/) - AI observability and evaluation platform with tracing, human annotation, and automated evaluation for LLM applications.
+* 🟢 [Coralogix](https://coralogix.com/) - Ingest all your data, store it indefinitely on your cloud, and query across all types with a unified syntax.
+* 🟢 [Datadog](https://www.datadoghq.com/) - A monitoring and security platform for cloud applications.
+* 🟢 [Dynatrace](https://www.dynatrace.com/) - Offers a unified observability and security platform powered by AI, providing analytics and automation for multicloud environments.
+* 🟢 [Elastic](https://www.elastic.co/) - Provides search-powered solutions for observability, security, and enterprise search.
+* 🟢 [Gigapipe](https://gigapipe.com/) - Provides unified polyglot observability platform for logs, metrics, traces and profiles with drop-in compatibility for Loki, Prometheus, Tempo, and Pyroscope.
+* 🟢 [Grafana](https://grafana.com/) - An open-source platform for monitoring and observability, enabling visualization of metrics, logs, and traces.
+* 🟢 [groundcover](https://www.groundcover.com/) - eBPF-based observability platform with BYOC architecture for logs, metrics, and traces.
+* 🟢 [Helicone](https://www.helicone.ai/) - Open-source LLM observability and monitoring platform.
+* 🟢 [Highlight](https://highlight.io/) - Open-source fullstack monitoring platform with session replay, error monitoring, logging, and traces.
+* 🟢 [Honeycomb](https://www.honeycomb.io/) - An observability platform that helps engineering teams understand, debug, and improve complex systems.
+* 🟢 [Kentik](https://www.kentik.com/) - Provides network observability solutions for performance monitoring and security.
+* 🟢 [Laminar](https://laminar.sh/) - Observability and analytics platform for LLM applications.
+* 🟢 [LogRocket](https://logrocket.com/) - Replays user sessions to help developers understand and fix issues faster.
+* 🟢 [Logz.io](https://logz.io/) - Offers an open-source observability platform for monitoring, troubleshooting, and securing applications.
+* 🟢 [Mezmo](https://www.mezmo.com/) - Provides a central observability platform to control, enrich, and correlate machine data for faster business decisions.
+* 🟢 [New Relic](https://newrelic.com/) - An observability platform that unifies metrics, events, logs, and traces for full-stack monitoring.
+* 🟢 [OpenStatus](https://www.openstatus.dev/) - Open-source status page and monitoring platform for tracking API and website uptime worldwide.
+* 🟢 [Sentry](https://sentry.io/) - Application monitoring platform for error tracking, performance monitoring, and session replay to identify and resolve code issues.
+* 🟢 [Splunk](https://www.splunk.com/) - Provides a platform for searching, monitoring, and analyzing machine-generated big data.
+* 🟢 [Sumo Logic](https://www.sumologic.com/) - Offers cloud-native machine data analytics for real-time insights into operations and security.
+* 🟢 [Weights & Biases](https://wandb.ai/) - AI developer platform for experiment tracking, model management, evaluation, and observability for ML and LLM applications.
+
 ## Data Integration & ETL
 
 Connectors, pipelines, and transformation tools for moving and synchronizing data between systems.
+
+* 🟢 [Airbyte](https://airbyte.com/) - Open-source data integration platform with 600+ connectors and CDK for custom integrations.
+* 🟡 [Arroyo](https://arroyo.dev) - Provides cloud-native stream processing engine built in Rust that enables real-time data transformation, filtering, aggregation, and joins using SQL with sub-second results.
+* 🟢 [dbt Labs](https://www.getdbt.com/) - Empowers data practitioners to transform data in their warehouses by developing, testing, and documenting analytics code.
+* 🟢 [Fivetran](https://www.fivetran.com/) - Automated data integration platform with 300+ connectors and zero-maintenance ETL pipelines.
+* 🟢 [Redpanda](https://www.redpanda.com/) - Kafka-compatible streaming data platform with built-in identity controls and policy enforcement for AI workloads.
+* 🟢 [Rivery](https://rivery.io/) - No-code data integration platform with visual workflows and 150+ connectors with built-in transformations.
 
 ## Workflow & Operations Clouds
 
@@ -282,14 +288,11 @@ CDN, DNS, private networking, interconnection, SD-WAN, API gateways, and tunneli
 * 🟢 [Akamai](https://www.akamai.com/) - A global content delivery and cybersecurity platform that helps secure and accelerate digital experiences at the edge.
 * 🟢 [Approximated](https://approximated.app/) - Custom domain proxy platform with global edge servers, SSL management, and DDoS protection.
 * 🟢 [Aviatrix](https://aviatrix.com/) - Provides a cloud-native networking platform with advanced multi-cloud transit, security, and observability features.
-* 🟢 [Boundary](https://www.boundaryproject.io/) - HashiCorp's secure remote access to systems and services.
 * 🟢 [c/Side](https://cside.dev/) - A next generation web security service that monitors, optimizes and secures 3rd party scripts.
 * 🟢 [Cloudbrink](https://cloudbrink.com/) - Delivers hybrid access-as-a-service with high-performance connectivity, zero trust security, and edge-native networking for remote users.
 * 🟢 [Cloudflare](https://www.cloudflare.com/) - Protects and accelerates websites and apps through global CDN, DDoS mitigation, Zero Trust access, and DNS services.
-* 🟢 [CrowdStrike](https://www.crowdstrike.com/) - A cloud-native cybersecurity platform that provides endpoint protection, threat intelligence, and incident response powered by AI.
 * 🟡 [CtrlDNS](https://www.ctrldns.com/) - Provides DNS management and control services for domain name resolution and network infrastructure management.
 * 🟢 [Fastly](https://www.fastly.com/) - An edge cloud platform designed for performance and security, enabling developers to build faster, more secure digital experiences.
-* 🟢 [Fortinet](https://www.fortinet.com/) - Provides integrated cybersecurity solutions including next-gen firewalls, secure SD-WAN, and endpoint protection.
 * 🟢 [IPinfo](https://ipinfo.io/) - Provides accurate IP address intelligence including geolocation, ASN data, privacy detection, and network information through APIs and data downloads for developers and enterprises.
 * 🟢 [Kong](https://konghq.com/) - An open-source API gateway and microservices management layer that provides traffic control, security, and observability for APIs.
 * 🟢 [LocalXpose](https://localxpose.io/) - Secure tunneling service supporting HTTP, TLS, TCP, UDP with custom domains and SSL.
@@ -297,141 +300,135 @@ CDN, DNS, private networking, interconnection, SD-WAN, API gateways, and tunneli
 * 🟢 [Megaport](https://www.megaport.com/) - Offers elastic interconnection services that allow businesses to rapidly connect to cloud providers, data centers, and networks.
 * 🟢 [NetBox Cloud](https://netboxlabs.com/netbox-cloud/) - A managed solution for network infrastructure modeling and documentation, providing a scalable and secure platform for network automation.
 * 🟢 [Netmaker](https://netmaker.io/) - A WireGuard-based virtual networking platform that enables fast, secure, and scalable networking for devices and distributed systems.
-* 🟢 [Netskope](https://www.netskope.com/) - A cloud-native security platform that protects users, apps, and data with visibility and control across SaaS, IaaS, and the web.
-* 🟢 [Operant](https://operant.ai/) - Provides runtime protection for cloud-native applications using graph-based detection and real-time observability.
 * 🟢 [Pangolin](https://digpangolin.com/) - Secure app exposure via WireGuard tunnels with identity-aware access control.
-* 🟢 [Pomerium](https://www.pomerium.com/) - Identity-aware access proxy for securing internal apps.
-* 🟢 [StrongDM](https://www.strongdm.com/) - Zero-trust access platform for infrastructure and databases.
 * 🟢 [Subspace](https://subspace.com/) - Dedicated network-as-a-service for real-time applications with global private fiber-optic network. Reduces latency up to 80% and packet loss by 99% for voice, video, gaming, and real-time apps with WebRTC acceleration and SIP proxy.
 * 🟢 [Tailscale](https://tailscale.com/) - A zero-config VPN built on WireGuard that makes secure networking between devices as easy as logging in.
-* 🟢 [Teleport](https://goteleport.com/) - Zero trust infrastructure access platform with cryptographic identity and least privileged access.
 * 🟢 [Twingate](https://www.twingate.com/) - Provides a modern zero-trust networking solution to securely connect people to private apps and services without VPNs.
 * 🟢 [Versa Networks](https://www.versa-networks.com/) - Delivers integrated SASE and SD-WAN solutions for secure, scalable, and simplified enterprise networking.
-* 🟢 [Wiz](https://www.wiz.io/) - A cloud security platform that gives full-stack visibility into cloud infrastructure and prioritizes risk across workloads, containers, and identities.
 * 🟢 [ZeroTier](https://www.zerotier.com/) - Provides secure peer-to-peer networking platform that connects devices, clouds, and networks globally without VPNs or complex infrastructure configuration.
 * 🟢 [zrok](https://zrok.io/) - Zero-trust tunneling platform for instant private or public sharing of applications, files, and services with automatic TLS and built-in security features.
-* 🟢 [Zscaler](https://www.zscaler.com/) - Zero trust SASE platform with AI-driven cybersecurity and cloud protection.
 
 ## AI Inference & Model APIs
-* 🟡 [Anchor](https://anchorbrowser.io/) - Provides AI-powered browser automation infrastructure with humanized Chromium instances that can access any website, handle authentication, and perform web tasks reliably.
-* 🟡 [Parallel](https://parallel.ai/) - Provides AI-optimized web search and data extraction APIs with high accuracy for AI agents and applications to access structured web intelligence.
 
 APIs and platforms for running inference on foundation models and open-source LLMs, with a focus on speed, cost, and scale.
+
+* 🟡 [Anchor](https://anchorbrowser.io/) - Provides AI-powered browser automation infrastructure with humanized Chromium instances that can access any website, handle authentication, and perform web tasks reliably.
+* 🟢 [Fireworks.ai](https://fireworks.ai/) - Delivers high-speed, cost-effective inference APIs with support for open-source models.
+* 🟢 [Groq](https://groq.com/) - Provides ultra-fast inference on custom hardware designed for AI workloads.
+* 🟢 [LeptonAI](https://lepton.ai/) - Provides infrastructure and tools to build and deploy AI models at scale.
+* 🟡 [Parallel](https://parallel.ai/) - Provides AI-optimized web search and data extraction APIs with high accuracy for AI agents and applications to access structured web intelligence.
+* 🟢 [Portkey](https://portkey.ai/) - AI Gateway control panel for production apps with unified gateway to 1600+ LLMs, observability, guardrails, and governance. OpenAI-compatible with semantic caching and SOC2/HIPAA/GDPR compliance.
+* 🟢 [Replicate](https://replicate.com/) - Run machine learning models in the cloud with an API.
+* 🟢 [Roboflow](https://roboflow.com/) - Offers tools for building and deploying computer vision models, simplifying data collection, annotation, and model training for developers.
+* 🟢 [Together.ai](https://www.together.ai/) - Open-source foundation model infrastructure with collaborative fine-tuning.
 
 ## AI Assistants & Copilots
 
 Conversational AI products, chat interfaces, and AI-powered search engines built for end users and knowledge workers.
 
 * 🟢 [AssemblyAI](https://www.assemblyai.com/) - Offers powerful speech-to-text and AI APIs for transcription, summarization, content moderation, and more.
-* 🟢 [Base44](https://base44.com/) - An all-in-one AI platform to easily build fully functioning apps without coding.
 * 🟢 [Bluedot](https://www.bluedothq.com/) - Bot-free AI meeting assistant that records, transcribes, and generates notes with automatic CRM updates.
 * 🟢 [Character.ai](https://character.ai/) - Lets users interact with and create AI-driven characters for entertainment, education, and companionship.
 * 🟢 [ChatGPT by OpenAI](https://openai.com/chatgpt) - OpenAI's conversational AI model that generates human-like text, answers questions, and assists with a wide range of tasks.
 * 🟢 [Chatsonic](https://chatsonic.com/) - An AI chatbot built on top of GPT that includes real-time search data and voice interaction capabilities.
 * 🟢 [Claude](https://claude.ai/) - An AI assistant from Anthropic focused on safe, helpful, and honest interactions, suitable for creative and technical workflows.
-* 🟢 [Codev](https://codev.ai/) - A development assistant that uses AI to generate, analyze, and debug software code efficiently.
 * 🟢 [Cohere](https://cohere.com/) - Enterprise AI platform with language models for automation, data insights, and custom solutions.
 * 🟢 [DeepAI](https://deepai.org/) - Offers a suite of open AI APIs for developers, including text, image, and moderation tools.
 * 🟢 [Deepseek](https://deepseek.com/) - Provides developer tools and research models for AI-powered coding, content generation, and reasoning tasks.
-* 🟢 [E2B](https://e2b.dev/) - Secure sandboxes for AI code execution with filesystem, networking, and long-running process support for AI agents.
 * 🟢 [ElevenLabs](https://elevenlabs.io/) - AI text-to-speech with ultra-realistic voices in 32+ languages, voice cloning, and conversational agents.
 * 🟢 [Elicit](https://elicit.org/) - An AI research assistant that helps automate tasks like literature reviews and hypothesis testing for academics and researchers.
-* 🟢 [Fireworks.ai](https://fireworks.ai/) - Delivers high-speed, cost-effective inference APIs with support for open-source models.
-* 🟢 [Gadget](https://gadget.dev/) - Full-stack framework with built-in database, auth, and deployment.
-* 🟢 [GitHub Copilot](https://github.com/features/copilot) - An AI-powered coding assistant developed by GitHub and OpenAI that suggests code snippets as you type.
-* 🟢 [Groq](https://groq.com/) - Provides ultra-fast inference on custom hardware designed for AI workloads.
-* 🟢 [Helicone](https://www.helicone.ai/) - Open-source LLM observability and monitoring platform.
-* 🟢 [Laminar](https://laminar.sh/) - Observability and analytics platform for LLM applications.
+* 🟢 [Kimi AI](https://www.kimi.com) - Provides AI-powered conversational assistance with visual coding capabilities, agent swarm technology, and deep research tools for enhanced productivity.
 * 🟢 [Layer 9](https://layer9.com/) - AI network engineer that configures, monitors, and repairs network devices with 24/7 automation.
-* 🟢 [LeptonAI](https://lepton.ai/) - Provides infrastructure and tools to build and deploy AI models at scale.
-* 🟢 [Lightning.ai](https://lightning.ai/) - Build, train, and deploy AI models with powerful tools and scalable infrastructure.
-* 🟢 [Marblism](https://www.marblism.com/) - Generate full-stack web apps from a single prompt.
 * 🟢 [NeuBird](https://neubird.ai/) - An autonomous AI SRE platform.
 * 🟢 [Parahelp](https://parahelp.com/) - AI support agent that automates complex customer support tickets end-to-end for software companies.
 * 🟢 [Perplexity](https://www.perplexity.ai/) - An AI-native search engine that answers questions with citations and real-time data.
 * 🟢 [Playground](https://playground.com/) - A tool for exploring and experimenting with generative AI across text, code, and image generation.
 * 🟢 [Poe](https://poe.com/) - A multi-AI chat interface by Quora that enables access to models like Claude, GPT-4, and more in one app.
-* 🟢 [Prismic](https://prismic.io/) - A headless CMS for developers to build and manage dynamic websites using modern frameworks and custom content APIs.
-* 🟢 [Replicate](https://replicate.com/) - Run machine learning models in the cloud with an API.
-* 🟢 [Replit](https://replit.com/) - Collaborative browser IDE with instant deployment and multiplayer coding.
 * 🟢 [Resolve.ai](https://resolve.ai/) - An agentic AI SRE from the co-creators of OpenTelemetry.
-* 🟢 [Retool](https://retool.com/) - A low-code platform to build custom internal tools quickly with pre-built components and database integrations.
-* 🟢 [Softgen](https://softgen.ai/) - Provides tools to automatically generate code, documentation, and tests to speed up software delivery.
-* 🟢 [StackBlitz](https://stackblitz.com/) - Instant full-stack dev environments running entirely in the browser.
+* 🟡 [SharonAI](https://sharonai.com/en/) - Provides AI-powered solutions and services for business automation and intelligent decision-making processes.
 * 🟢 [Supertrace AI](https://supertrace.ai/) - AI-powered network engineer platform for automating IT network management and infrastructure operations.
 * 🟢 [Surfer AI](https://surferseo.com/ai/) - Uses AI to generate SEO-optimized content and blog articles with built-in search analysis tools.
 * 🟢 [Tavus](https://www.tavus.io/) - AI-powered conversational video platform with real-time face-to-face AI humans.
-* 🟢 [Together.ai](https://www.together.ai/) - Open-source foundation model infrastructure with collaborative fine-tuning.
-* 🟢 [v0](https://v0.app/) - AI-powered UI generation from text prompts to React code.
-* 🟢 [Windsurf](https://windsurf.com/) - An AI powered coding engine and IDE that is an alternative to GitHub Copilot. Formerly Codeium.
 
 ## AI Coding & App Generation
-* 🟡 [Git AI](https://usegitai.com/) - Provides open-source Git extension for tracking AI-generated code through the entire software development lifecycle with attribution, context storage, and team analytics.
-* 🟢 [OB-1](https://www.openblocklabs.com/) - Provides a self-improving coding agent that handles the full development lifecycle from project management to pull requests, with multi-model AI support and workflow automation.
 
 AI-powered code editors, IDEs, no-code/low-code builders, and full-stack app generation tools.
+
+* 🟢 [Base44](https://base44.com/) - An all-in-one AI platform to easily build fully functioning apps without coding.
+* 🟢 [Bolt](https://bolt.new/) - A browser-based AI development environment that lets you generate, edit, and deploy full-stack applications instantly using natural language prompts.
+* 🟢 [Codev](https://codev.ai/) - A development assistant that uses AI to generate, analyze, and debug software code efficiently.
+* 🟢 [CopilotKit](https://www.copilotkit.ai/) - Open-source framework and infrastructure for building in-app AI copilots and agents.
+* 🟢 [Cursor](https://www.cursor.so/) - An AI-enhanced code editor that integrates directly with your codebase to provide suggestions and automate changes.
+* 🟡 [Git AI](https://usegitai.com/) - Provides open-source Git extension for tracking AI-generated code through the entire software development lifecycle with attribution, context storage, and team analytics.
+* 🟢 [GitHub Copilot](https://github.com/features/copilot) - An AI-powered coding assistant developed by GitHub and OpenAI that suggests code snippets as you type.
+* 🟢 [Marblism](https://www.marblism.com/) - Generate full-stack web apps from a single prompt.
+* 🟢 [Mesa](https://www.mesa.dev) - AI-powered code review platform with custom agents that learn codebase standards and prevent tech debt.
+* 🟢 [OB-1](https://www.openblocklabs.com/) - Provides a self-improving coding agent that handles the full development lifecycle from project management to pull requests, with multi-model AI support and workflow automation.
+* 🟢 [Softgen](https://softgen.ai/) - Provides tools to automatically generate code, documentation, and tests to speed up software delivery.
+* 🟢 [Tabnine](https://www.tabnine.com/) - AI code assistant with private model options.
+* 🟢 [v0](https://v0.app/) - AI-powered UI generation from text prompts to React code.
+* 🟢 [Windsurf](https://windsurf.com/) - An AI powered coding engine and IDE that is an alternative to GitHub Copilot. Formerly Codeium.
 
 ## PaaS & Application Hosting
 
 Platform-as-a-service and managed hosting providers for deploying and scaling web applications, APIs, and services.
 
+* 🟢 [Deno Deploy](https://deno.com/deploy) - Globally distributed edge platform for JavaScript and TypeScript serverless apps.
+* 🟢 [Flightcontrol](https://www.flightcontrol.dev/) - Automates infrastructure provisioning, CI/CD, and deployments within your own AWS account, offering full visibility and control.
+* 🟢 [Fly](https://fly.io) - Provides a platform to deploy applications globally with low latency.
+* 🟢 [Gadget](https://gadget.dev/) - Full-stack framework with built-in database, auth, and deployment.
+* 🟢 [Heroku](https://www.heroku.com/) - Offers a platform as a service (PaaS) for deploying and managing applications.
+* 🟢 [Koyeb](https://www.koyeb.com/) - Offers a serverless platform to deploy applications globally.
+* 🟢 [Netlify](https://www.netlify.com/) - Platform for building, deploying, and scaling modern web applications.
+* 🟢 [Northflank](https://northflank.com/) - A platform to build, deploy, and manage full-stack applications.
+* 🟢 [Pantheon](https://pantheon.io/) - A platform for running Wordpress, Drupal and Next.js websites.
+* 🟢 [Platform.sh](https://platform.sh/) - Enterprise PaaS to build, run, and scale web applications and microservices.
+* 🟢 [Porter](https://porter.run/) - A Kubernetes-powered PaaS that runs in your own cloud provider, simplifying the deployment and management of applications on AWS, GCP, or Azure.
+* 🟢 [Puter](https://puter.com/) - A privacy-first personal cloud that houses all your files, apps, and games in one secure place, accessible from anywhere at any time.
+* 🟢 [Railway](https://railway.com/) - Deploy code instantly and manage environments in the cloud.
+* 🟢 [Render](https://render.com/) - Unified cloud platform to build and host apps, websites, and agent workflows.
+* 🟢 [Shuttle](https://www.shuttle.dev/) - Rust-native cloud platform for building and deploying backend services.
 * 🟢 [Skyhook](https://skyhook.io/) - PaaS for deploying and managing Kubernetes clusters and workloads with GitOps support, preview environments, and AI assistance.
+* 🟢 [Upsun](https://upsun.com/) - An application hosting platform from the team at Platform.sh.
 
 ## Developer Tooling & CI/CD
 
 Build systems, artifact registries, CI/CD pipelines, cloud dev environments, testing frameworks, feature flags, and developer productivity tools.
 
-* 🟢 [Bolt](https://bolt.new/) - A browser-based AI development environment that lets you generate, edit, and deploy full-stack applications instantly using natural language prompts.
+* 🟢 [Browserbase](https://www.browserbase.com/) - A platform for running headless browsers for interact with websites via automation.
 * 🟢 [browserless](https://www.browserless.io/) - Headless browser automation platform providing managed Chrome, Firefox, and WebKit browsers for scraping, testing, and automation with bot detection bypass and CAPTCHA solving.
 * 🟢 [Bubble](https://bubble.io/) - No-code visual programming platform for building web and mobile apps with drag-and-drop interface and usage-based pricing.
 * 🟢 [Cloudsmith](https://cloudsmith.com/) - Cloud-native artifact management supporting 30+ formats with security scanning, policy engine, and global CDN delivery.
 * 🟢 [Coder](https://coder.com/) - Offers self-hosted cloud development environments that provision and manage workspaces, enabling developers to code from anywhere with enhanced security and scalability.
-* 🟢 [CopilotKit](https://www.copilotkit.ai/) - Open-source framework and infrastructure for building in-app AI copilots and agents.
-* 🟢 [Cursor](https://www.cursor.so/) - An AI-enhanced code editor that integrates directly with your codebase to provide suggestions and automate changes.
 * 🟢 [Cypress](https://www.cypress.io/) - Browser testing framework for modern web applications with AI-powered test generation and self-healing capabilities.
-* 🟢 [Deno Deploy](https://deno.com/deploy) - Globally distributed edge platform for JavaScript and TypeScript serverless apps.
 * 🟢 [Depot](https://depot.dev/) - Accelerates Docker builds and GitHub Actions with up to 20x faster performance through optimized compute and caching.
 * 🟢 [DevZero](https://www.devzero.io/) - Delivers production-like cloud development environments using MicroVMs, combining the performance of containers with the isolation of VMs.
 * 🟢 [Dosu](https://dosu.dev/) - AI documentation platform that generates, maintains, and shares knowledge from code and conversations.
+* 🟢 [E2B](https://e2b.dev/) - Secure sandboxes for AI code execution with filesystem, networking, and long-running process support for AI agents.
 * 🟢 [Fabrica](https://www.usefabrica.app/) - AI platform that builds internal apps from prompts with database and tooling integrations.
 * 🟢 [Firefly](https://www.firefly.ai/) - A cloud asset management solution powered by Infrastructure-as-Code, assisting DevOps and SRE teams in managing their entire cloud infrastructure efficiently.
 * 🟢 [Flagsmith](https://www.flagsmith.com/) - Open-source feature flag and remote config platform with SaaS, self-hosted, or private cloud deployment options.
-* 🟢 [Flightcontrol](https://www.flightcontrol.dev/) - Automates infrastructure provisioning, CI/CD, and deployments within your own AWS account, offering full visibility and control.
-* 🟢 [Fly](https://fly.io) - Provides a platform to deploy applications globally with low latency.
 * 🟢 [Gammacode](https://gammacode.dev/) - AI code intelligence platform with CLI/web interface, security scanning, and issue automation.
-* 🟢 [Gigapipe](https://gigapipe.com/) - Provides unified polyglot observability platform for logs, metrics, traces and profiles with drop-in compatibility for Loki, Prometheus, Tempo, and Pyroscope.
-* 🟢 [GitHub](https://github.com/) - The world's leading platform for version control and collaboration, offering GitHub Codespaces for instant, cloud-based development environments.
-* 🟢 [GitLab](https://gitlab.com/) - Managed Git hosting with CI/CD and integrated privacy-first AI workflows.
 * 🟢 [Gitpod](https://www.gitpod.io/) - A platform for automated and standardized development environments, enabling developers to code from anywhere with pre-configured, on-demand workspaces.
 * 🟢 [HashiCorp Cloud Platform](https://www.hashicorp.com/cloud) - A fully-managed platform offering HashiCorp products-as-a-service, simplifying infrastructure and security management for developers.
 * 🟢 [Helix](https://helix.ml/) - Provides agent virtualization and fleet orchestration platform with isolated desktop environments for AI agents on Mac, Linux, and Kubernetes infrastructure.
-* 🟢 [Heroku](https://www.heroku.com/) - Offers a platform as a service (PaaS) for deploying and managing applications.
 * 🟢 [JetBrains](https://www.jetbrains.com/) - Intelligent development tools and IDEs including IntelliJ IDEA and Kotlin language.
-* 🟢 [Kimi AI](https://www.kimi.com) - Provides AI-powered conversational assistance with visual coding capabilities, agent swarm technology, and deep research tools for enhanced productivity.
-* 🟢 [Koyeb](https://www.koyeb.com/) - Offers a serverless platform to deploy applications globally.
 * 🟢 [Lightrun](https://lightrun.com/) - An AI platform to autonomously detect, debug, and remediate runtime issues.
 * 🟢 [Linear](https://linear.app/) - Purpose-built tool for planning, tracking issues, and managing product roadmaps.
-* 🟢 [Mesa](https://www.mesa.dev) - AI-powered code review platform with custom agents that learn codebase standards and prevent tech debt.
 * 🟢 [Mintlify](https://mintlify.com/) - Modern documentation platform with MDX support, API references, interactive components, and built-in search analytics.
-* 🟢 [Netlify](https://www.netlify.com/) - Platform for building, deploying, and scaling modern web applications.
-* 🟢 [Northflank](https://northflank.com/) - A platform to build, deploy, and manage full-stack applications.
 * 🟢 [Notion](https://www.notion.com/) - All-in-one workspace for notes, docs, wikis, and project management.
 * 🟢 [Outerbase](https://www.outerbase.com/) - A platform for safely interacting with data and databases, now part of Cloudflare.
-* 🟢 [Pantheon](https://pantheon.io/) - A platform for running Wordpress, Drupal and Next.js websites.
-* 🟢 [Platform.sh](https://platform.sh/) - Enterprise PaaS to build, run, and scale web applications and microservices.
-* 🟢 [Porter](https://porter.run/) - A Kubernetes-powered PaaS that runs in your own cloud provider, simplifying the deployment and management of applications on AWS, GCP, or Azure.
-* 🟢 [Portkey](https://portkey.ai/) - AI Gateway control panel for production apps with unified gateway to 1600+ LLMs, observability, guardrails, and governance. OpenAI-compatible with semantic caching and SOC2/HIPAA/GDPR compliance.
-* 🟢 [Railway](https://railway.com/) - Deploy code instantly and manage environments in the cloud.
+* 🟢 [Prismic](https://prismic.io/) - A headless CMS for developers to build and manage dynamic websites using modern frameworks and custom content APIs.
 * 🟢 [Release](https://release.com/) - Enables the creation and management of on-demand, ephemeral environments, streamlining development workflows and reducing costs.
-* 🟢 [Render](https://render.com/) - Unified cloud platform to build and host apps, websites, and agent workflows.
-* 🟢 [Roboflow](https://roboflow.com/) - Offers tools for building and deploying computer vision models, simplifying data collection, annotation, and model training for developers.
+* 🟢 [Replit](https://replit.com/) - Collaborative browser IDE with instant deployment and multiplayer coding.
+* 🟢 [Retool](https://retool.com/) - A low-code platform to build custom internal tools quickly with pre-built components and database integrations.
 * 🟢 [Runloop](https://runloop.ai/) - Provides secure cloud-based development environments (devboxes) for AI coding agents with enterprise-grade infrastructure, benchmarking tools, and scalable sandbox execution.
-* 🟢 [Shuttle](https://www.shuttle.dev/) - Rust-native cloud platform for building and deploying backend services.
-* 🟢 [Tabnine](https://www.tabnine.com/) - AI code assistant with private model options.
+* 🟢 [StackBlitz](https://stackblitz.com/) - Instant full-stack dev environments running entirely in the browser.
 * 🟡 [Tensorlake](https://www.tensorlake.ai/) - Provides a complete platform for deploying production AI agents with durable execution, document ingestion, code sandboxes, and multi-cloud compute infrastructure.
 * 🟢 [Tiptap](https://tiptap.dev/) - Headless rich text editor with real-time collaboration, AI content generation, and 100+ extensions.
 * 🟢 [Ubicloud](https://www.ubicloud.com/) - An open-source cloud platform that can run anywhere, offering IaaS features on bare metal providers with options for self-hosting or managed services.
 * 🟢 [Unleash](https://www.getunleash.io/) - Enterprise open-source feature management platform with strong RBAC and flexible deployment options.
+* 🟢 [Warp](https://www.warp.dev/) - Cloud service provider.
 
 ## Authorization, Identity & Fraud
 
@@ -442,6 +439,7 @@ Authentication, authorization, secrets management, identity providers, and fraud
 * 🟢 [Auth0](https://auth0.com/) - A flexible, drop-in solution to add authentication and authorization services to applications, now part of Okta.
 * 🟢 [Authzed](https://authzed.com/) - Provides fine-grained, scalable authorization as a service, built on the open-source SpiceDB.
 * 🟢 [Bolster](https://bolster.ai/) - A platform for preventing and mitigrating phishing and impersonation scams.
+* 🟢 [Boundary](https://www.boundaryproject.io/) - HashiCorp's secure remote access to systems and services.
 * 🟢 [Cerbos](https://cerbos.dev/) - Open-source authorization with policy-as-code for access control.
 * 🟢 [CipherStash](https://cipherstash.com/) - Zero-trust encryption platform with searchable encryption, identity-based access control, and real-time audit trails.
 * 🟢 [Clerk](https://clerk.com/) - Offers a complete suite of embeddable UIs and APIs for user authentication and management.
@@ -458,9 +456,12 @@ Authentication, authorization, secrets management, identity providers, and fraud
 * 🟢 [Oso](https://www.osohq.com/) - Authorization framework with policy-as-code, permissions for agent security.
 * 🟢 [Pangea](https://pangea.cloud/) - Security services API platform for auth, vault, audit, and more.
 * 🟢 [Permit](https://www.permit.io/) - Authorization-as-a-Service platform for baking-in access control in minutes.
+* 🟢 [Pomerium](https://www.pomerium.com/) - Identity-aware access proxy for securing internal apps.
 * 🟢 [PropelAuth](https://www.propelauth.com/) - B2B authentication and user management for multi-tenant apps.
 * 🟢 [Sift Science](https://sift.com/) - Utilizes machine learning to provide real-time fraud detection and prevention solutions.
+* 🟢 [StrongDM](https://www.strongdm.com/) - Zero-trust access platform for infrastructure and databases.
 * 🟡 [Stytch](https://stytch.com/) - Provides APIs and SDKs for passwordless authentication, including email magic links, SMS passcodes, and biometrics.
+* 🟢 [Teleport](https://goteleport.com/) - Zero trust infrastructure access platform with cryptographic identity and least privileged access.
 * 🟢 [Warrant](https://warrant.dev/) - Authorization and access control as a service.
 * 🟢 [WorkOS](https://workos.com/) - Offers enterprise-ready authentication solutions, including single sign-on and directory synchronization.
 * 🟢 [Xpander.ai](http://xpander.ai/) - Backend-as-a-Service for AI agents with managed hosting and function libraries.
@@ -513,6 +514,7 @@ CRM, customer engagement, marketing automation, newsletter, and eCommerce platfo
 Messaging, notifications, email, voice, video, and IoT connectivity platforms for building connected products and real-time communication.
 
 * 🟢 [1NCE](https://www.1nce.com/en-us/) - Offers flat-rate global cellular connectivity for IoT devices, including SIM management and low-bandwidth data plans designed for scale.
+* 🟢 [api.video](https://api.video/) - Developer-first video API for encoding, hosting, streaming.
 * 🟢 [Gradium](https://gradium.ai/) - Provides audio language models for natural, expressive, ultra-low latency voice interactions with text-to-speech and speech-to-text capabilities in multiple languages.
 * 🟢 [Hologram](https://www.hologram.io/) - Provides global IoT SIM cards and eUICC technology with a cloud-native dashboard for managing devices and data usage across carriers.
 * 🟢 [Knock](https://knock.app/) - Notification infrastructure with workflows, preferences, and delivery channels.
@@ -538,6 +540,8 @@ Decentralized compute networks and blockchain-based infrastructure for running w
 Version control hosting and collaboration platforms for managing source code changes over time.
 
 * 🟢 [Gitea Cloud](https://about.gitea.com/products/cloud/) - Single-tenant managed Git hosting with built-in CI/CD and private isolated environments.
+* 🟢 [GitHub](https://github.com/) - The world's leading platform for version control and collaboration, offering GitHub Codespaces for instant, cloud-based development environments.
+* 🟢 [GitLab](https://gitlab.com/) - Managed Git hosting with CI/CD and integrated privacy-first AI workflows.
 
 ## Cloud Adjacent & Infrastructure Tooling
 
@@ -554,20 +558,20 @@ Services that show promise but don't yet fully meet Alt Cloud criteria (public p
 
 Why track these? The cloud landscape changes fast. Today's "contact sales only" can become tomorrow's self-service leader. This section helps monitor emerging players and hold established vendors accountable to transparency.
 
-* 🟢 [Oxide Computer](https://oxide.computer/) - Rack-scale cloud computer for on-premises with unified hardware/software, but sold as CapEx hardware (~$1M/rack) rather than usage-based cloud service.
 * 🟢 [API7](https://api7.ai/) - Commercial distribution of Apache APISIX with cloud offerings, pending pricing transparency verification.
 * 🟢 [Apigee](https://cloud.google.com/apigee) - Google's API management platform with advanced features but enterprise-only pricing model.
-* 🟢 [KrakenD](https://www.krakend.io/) - High-performance API gateway, needs cloud pricing model verification.
-* 🟢 [OpenObserve](https://openobserve.ai/) - Open-source observability platform, cloud service SLA needs verification.
-* 🟢 [Uptrace](https://uptrace.dev/) - Distributed tracing and metrics platform built on OpenTelemetry, verification needed.
 * 🟢 [Chroma](https://www.trychroma.com/) - Open-source vector database, managed cloud service details need verification.
-* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database optimized for speed, service verification needed.
 * 🟢 [Eppo](https://www.geteppo.com/) - Feature flagging and experimentation platform (acquired by Datadog May 2025).
 * 🟢 [FeatBit](https://featbit.co/) - Open-source feature flags, cloud service verification needed.
+* 🟢 [KrakenD](https://www.krakend.io/) - High-performance API gateway, needs cloud pricing model verification.
 * 🟢 [LaunchDarkly](https://launchdarkly.com/) - Industry-leading feature management with $20k-$120k/year pricing but no public transparency.
+* 🟢 [OpenObserve](https://openobserve.ai/) - Open-source observability platform, cloud service SLA needs verification.
+* 🟢 [Oxide Computer](https://oxide.computer/) - Rack-scale cloud computer for on-premises with unified hardware/software, but sold as CapEx hardware (~$1M/rack) rather than usage-based cloud service.
 * 🟢 [Split](https://www.split.io/) - Feature delivery platform with experimentation, enterprise-only pricing.
 * 🟢 [Statsig](https://statsig.com/) - Experimentation and feature flags platform (acquired by OpenAI Sept 2025, service status TBD).
 * 🟢 [Tggl](https://tggl.io/) - Feature flags platform, verification needed.
+* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database optimized for speed, service verification needed.
+* 🟢 [Uptrace](https://uptrace.dev/) - Distributed tracing and metrics platform built on OpenTelemetry, verification needed.
 
 ## Contributing
 

--- a/docs/clouds.json
+++ b/docs/clouds.json
@@ -1,32 +1,5 @@
 [
   {
-    "name": "Aethir",
-    "url": "https://aethir.com",
-    "description": "Provides secure, cost-effective access to enterprise-grade GPUs worldwide through a distributed cloud compute infrastructure.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Anyscale",
-    "url": "https://www.anyscale.com/",
-    "description": "Distributed computing platform built on Ray for scaling AI and Python apps.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "api.video",
-    "url": "https://api.video/",
-    "description": "Developer-first video API for encoding, hosting, streaming.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Arcade",
     "url": "https://www.arcade.dev/",
     "description": "Cloud service provider.",
@@ -54,24 +27,6 @@
     ]
   },
   {
-    "name": "Banana.dev",
-    "url": "https://www.banana.dev/",
-    "description": "Serverless GPU platform for ML model inference with pay-per-millisecond pricing.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Baseten",
-    "url": "https://www.baseten.co/",
-    "description": "Enables fast, reliable model inference with flexible deployment options, including self-hosted and hybrid.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Beam",
     "url": "https://www.beam.cloud",
     "description": "Cloud infrastructure specifically built for high-performance applications and developer happiness.",
@@ -90,24 +45,6 @@
     ]
   },
   {
-    "name": "Browserbase",
-    "url": "https://www.browserbase.com/",
-    "description": "A platform for running headless browsers for interact with websites via automation.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Cerebrium",
-    "url": "https://www.cerebrium.ai/",
-    "description": "Serverless GPU infrastructure for deploying ML models with auto-scaling.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Civo",
     "url": "https://www.civo.com",
     "description": "Provides cloud services with a focus on simplicity and developer experience.",
@@ -117,45 +54,9 @@
     ]
   },
   {
-    "name": "CoreWeave",
-    "url": "https://www.coreweave.com/",
-    "description": "A cloud platform optimized for AI, offering high-performance GPU compute and managed services.",
-    "score": 2,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Crusoe Energy",
-    "url": "https://crusoecloud.com/",
-    "description": "Energy-efficient GPU computing using stranded and renewable energy sources.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Cudo Compute",
-    "url": "https://www.cudocompute.com/",
-    "description": "Offers decentralized cloud computing with GPU support for AI applications.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Cycle.io",
     "url": "https://cycle.io/",
     "description": "Provides a container orchestration platform for deploying applications.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Datacrunch.io",
-    "url": "https://datacrunch.io/",
-    "description": "Provides affordable GPU cloud services for AI training and inference.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -207,36 +108,9 @@
     ]
   },
   {
-    "name": "Fal.ai",
-    "url": "https://fal.ai/",
-    "description": "Provides serverless GPU inference for AI models with instant deployment.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Firmus",
     "url": "https://firmus.co/",
     "description": "Cloud service provider.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "FluidStack",
-    "url": "https://www.fluidstack.io/",
-    "description": "Offers decentralized GPU cloud computing for AI and rendering workloads.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "FriendliAI",
-    "url": "https://friendli.ai/",
-    "description": "Fast AI inference platform with 2-3x speed boost. Deploy 490K+ models instantly. Serverless & dedicated GPU options. 99.99% SLA.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -261,33 +135,6 @@
     ]
   },
   {
-    "name": "Genesis Cloud",
-    "url": "https://www.genesiscloud.com/pricing",
-    "description": "Offers sustainable, high-performance GPU cloud computing for AI workloads.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "GMI Cloud",
-    "url": "https://www.gmicloud.ai/",
-    "description": "Provides GPU cloud services optimized for AI and deep learning tasks.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "GPU CLI",
-    "url": "https://gpu-cli.sh",
-    "description": "Provides command-line access to remote cloud GPUs with auto-stop functionality, instant connection, and automatic result syncing for ML training and inference workloads.",
-    "score": 2,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Hetzner",
     "url": "https://www.hetzner.com/",
     "description": "Provides dedicated servers and cloud services in Europe.",
@@ -300,33 +147,6 @@
     "name": "Hivelocity",
     "url": "https://www.hivelocity.net/",
     "description": "Experienced provider of VPS and bare metal solutions.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "HydraHost",
-    "url": "https://hydrahost.com/",
-    "description": "Affordable GPU compute focused on researchers and indie developers.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Hyperbolic",
-    "url": "https://hyperbolic.xyz/",
-    "description": "Offers scalable GPU compute for AI applications with a focus on performance and cost-efficiency.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Hyperstack",
-    "url": "https://www.hyperstack.cloud/",
-    "description": "Cloud GPU and AI platform for building, training, and deploying custom AI models.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -351,27 +171,9 @@
     ]
   },
   {
-    "name": "Lambda Labs",
-    "url": "https://lambda.ai/",
-    "description": "Delivers on-demand access to NVIDIA GPUs for AI training and inference.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Latitude.sh",
     "url": "https://www.latitude.sh/",
     "description": "Provides global bare metal servers for developers.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "LeaderGPU",
-    "url": "https://www.leadergpu.com/",
-    "description": "Provides high-performance GPU servers for rent, optimized for AI tasks.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -405,15 +207,6 @@
     ]
   },
   {
-    "name": "Modal",
-    "url": "https://modal.com/",
-    "description": "A serverless platform for AI and data teams to run compute-intensive applications without managing infrastructure.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Namespace",
     "url": "https://namespace.so/",
     "description": "Cloud service provider.",
@@ -423,36 +216,9 @@
     ]
   },
   {
-    "name": "Nebius",
-    "url": "https://nebius.com/",
-    "description": "Provides AI-centric cloud infrastructure with large-scale GPU clusters and managed services.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "NeevCloud",
-    "url": "https://www.neevcloud.com/",
-    "description": "India-based GPU cloud offering secure, scalable AI compute.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "NetActuate",
     "url": "https://netactuate.com/",
     "description": "Provides hybrid cloud and edge computing solutions with a global network.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "NextGen Cloud",
-    "url": "https://www.nextgencloud.com/",
-    "description": "Delivers sustainable, high-performance cloud infrastructure for AI workloads.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -472,24 +238,6 @@
     "url": "https://us.ovhcloud.com/",
     "description": "Global cloud provider offering compute, storage, and network solutions.",
     "score": 2,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Paperspace",
-    "url": "https://www.paperspace.com/",
-    "description": "Cloud computing with GPU support for AI development and deployment. Now owned by DigitalOcean.",
-    "score": 2,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Parasail",
-    "url": "https://parasail.ai/",
-    "description": "Serverless GPU platform to run custom AI models easily.",
-    "score": 3,
     "categories": [
       "Infrastructure Clouds"
     ]
@@ -516,15 +264,6 @@
     "name": "Rackspace",
     "url": "https://www.rackspace.com/",
     "description": "Provides hybrid cloud and managed hosting services.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Runpod",
-    "url": "https://www.runpod.io/",
-    "description": "Provides customizable GPU containers and secure cloud compute environments.",
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
@@ -576,24 +315,6 @@
     ]
   },
   {
-    "name": "Shadeform",
-    "url": "https://shadeform.com/",
-    "description": "GPU compute provider with a focus on low-cost AI infrastructure.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "SharonAI",
-    "url": "https://sharonai.com/en/",
-    "description": "Provides AI-powered solutions and services for business automation and intelligent decision-making processes.",
-    "score": 2,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Spheron Network",
     "url": "https://www.spheron.network/",
     "description": "Decentralized GPU/CPU network for AI and Web3 with 44,000+ nodes across 170+ locations.",
@@ -621,69 +342,6 @@
     ]
   },
   {
-    "name": "TensorDock",
-    "url": "https://tensordock.com/",
-    "description": "Affordable, usage-based GPU cloud platform for model training.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "TensorWave",
-    "url": "https://tensorwave.com/",
-    "description": "An AI cloud focused on AMD technology including MI325X and MI300X accelerators.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Thunder Compute",
-    "url": "https://www.thundercompute.com/",
-    "description": "Provides on-demand GPU instances with RTX A6000, A100, and H100 options at competitive pricing, featuring VS Code integration and one-click deployment for ML development.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Turboscale",
-    "url": "https://www.turboscale.ai/",
-    "description": "AI-native cloud infrastructure for fine-tuning and inference.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Upsun",
-    "url": "https://upsun.com/",
-    "description": "An application hosting platform from the team at Platform.sh.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Vast.ai",
-    "url": "https://vast.ai/",
-    "description": "Marketplace for buying and selling GPU compute capacity at competitive rates.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
-    "name": "Voltage Park",
-    "url": "https://www.voltagepark.com/",
-    "description": "AI cloud with 24,000 NVIDIA H100 GPUs and InfiniBand clusters for large-scale training.",
-    "score": 3,
-    "categories": [
-      "Infrastructure Clouds"
-    ]
-  },
-  {
     "name": "Vultr",
     "url": "https://www.vultr.com/",
     "description": "Full services cloud and hosting provider with an expanding range of solutions globally.",
@@ -693,12 +351,336 @@
     ]
   },
   {
-    "name": "Warp",
-    "url": "https://www.warp.dev/",
-    "description": "Cloud service provider.",
+    "name": "Aethir",
+    "url": "https://aethir.com",
+    "description": "Provides secure, cost-effective access to enterprise-grade GPUs worldwide through a distributed cloud compute infrastructure.",
     "score": 3,
     "categories": [
-      "Infrastructure Clouds"
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Anyscale",
+    "url": "https://www.anyscale.com/",
+    "description": "Distributed computing platform built on Ray for scaling AI and Python apps.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Banana.dev",
+    "url": "https://www.banana.dev/",
+    "description": "Serverless GPU platform for ML model inference with pay-per-millisecond pricing.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Baseten",
+    "url": "https://www.baseten.co/",
+    "description": "Enables fast, reliable model inference with flexible deployment options, including self-hosted and hybrid.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Cerebrium",
+    "url": "https://www.cerebrium.ai/",
+    "description": "Serverless GPU infrastructure for deploying ML models with auto-scaling.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "CoreWeave",
+    "url": "https://www.coreweave.com/",
+    "description": "A cloud platform optimized for AI, offering high-performance GPU compute and managed services.",
+    "score": 2,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Crusoe Energy",
+    "url": "https://crusoecloud.com/",
+    "description": "Energy-efficient GPU computing using stranded and renewable energy sources.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Cudo Compute",
+    "url": "https://www.cudocompute.com/",
+    "description": "Offers decentralized cloud computing with GPU support for AI applications.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Datacrunch.io",
+    "url": "https://datacrunch.io/",
+    "description": "Provides affordable GPU cloud services for AI training and inference.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Fal.ai",
+    "url": "https://fal.ai/",
+    "description": "Provides serverless GPU inference for AI models with instant deployment.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "FluidStack",
+    "url": "https://www.fluidstack.io/",
+    "description": "Offers decentralized GPU cloud computing for AI and rendering workloads.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "FriendliAI",
+    "url": "https://friendli.ai/",
+    "description": "Fast AI inference platform with 2-3x speed boost. Deploy 490K+ models instantly. Serverless & dedicated GPU options. 99.99% SLA.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Genesis Cloud",
+    "url": "https://www.genesiscloud.com/pricing",
+    "description": "Offers sustainable, high-performance GPU cloud computing for AI workloads.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "GMI Cloud",
+    "url": "https://www.gmicloud.ai/",
+    "description": "Provides GPU cloud services optimized for AI and deep learning tasks.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "GPU CLI",
+    "url": "https://gpu-cli.sh",
+    "description": "Provides command-line access to remote cloud GPUs with auto-stop functionality, instant connection, and automatic result syncing for ML training and inference workloads.",
+    "score": 2,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "HydraHost",
+    "url": "https://hydrahost.com/",
+    "description": "Affordable GPU compute focused on researchers and indie developers.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Hyperbolic",
+    "url": "https://hyperbolic.xyz/",
+    "description": "Offers scalable GPU compute for AI applications with a focus on performance and cost-efficiency.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Hyperstack",
+    "url": "https://www.hyperstack.cloud/",
+    "description": "Cloud GPU and AI platform for building, training, and deploying custom AI models.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Lambda Labs",
+    "url": "https://lambda.ai/",
+    "description": "Delivers on-demand access to NVIDIA GPUs for AI training and inference.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "LeaderGPU",
+    "url": "https://www.leadergpu.com/",
+    "description": "Provides high-performance GPU servers for rent, optimized for AI tasks.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Lightning.ai",
+    "url": "https://lightning.ai/",
+    "description": "Build, train, and deploy AI models with powerful tools and scalable infrastructure.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Modal",
+    "url": "https://modal.com/",
+    "description": "A serverless platform for AI and data teams to run compute-intensive applications without managing infrastructure.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Nebius",
+    "url": "https://nebius.com/",
+    "description": "Provides AI-centric cloud infrastructure with large-scale GPU clusters and managed services.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "NeevCloud",
+    "url": "https://www.neevcloud.com/",
+    "description": "India-based GPU cloud offering secure, scalable AI compute.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "NextGen Cloud",
+    "url": "https://www.nextgencloud.com/",
+    "description": "Delivers sustainable, high-performance cloud infrastructure for AI workloads.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Paperspace",
+    "url": "https://www.paperspace.com/",
+    "description": "Cloud computing with GPU support for AI development and deployment. Now owned by DigitalOcean.",
+    "score": 2,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Parasail",
+    "url": "https://parasail.ai/",
+    "description": "Serverless GPU platform to run custom AI models easily.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Runpod",
+    "url": "https://www.runpod.io/",
+    "description": "Provides customizable GPU containers and secure cloud compute environments.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Shadeform",
+    "url": "https://shadeform.com/",
+    "description": "GPU compute provider with a focus on low-cost AI infrastructure.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "TensorDock",
+    "url": "https://tensordock.com/",
+    "description": "Affordable, usage-based GPU cloud platform for model training.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "TensorWave",
+    "url": "https://tensorwave.com/",
+    "description": "An AI cloud focused on AMD technology including MI325X and MI300X accelerators.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Thunder Compute",
+    "url": "https://www.thundercompute.com/",
+    "description": "Provides on-demand GPU instances with RTX A6000, A100, and H100 options at competitive pricing, featuring VS Code integration and one-click deployment for ML development.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Turboscale",
+    "url": "https://www.turboscale.ai/",
+    "description": "AI-native cloud infrastructure for fine-tuning and inference.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Vast.ai",
+    "url": "https://vast.ai/",
+    "description": "Marketplace for buying and selling GPU compute capacity at competitive rates.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "Voltage Park",
+    "url": "https://www.voltagepark.com/",
+    "description": "AI cloud with 24,000 NVIDIA H100 GPUs and InfiniBand clusters for large-scale training.",
+    "score": 3,
+    "categories": [
+      "GPU & AI Compute Clouds"
+    ]
+  },
+  {
+    "name": "CrowdStrike",
+    "url": "https://www.crowdstrike.com/",
+    "description": "A cloud-native cybersecurity platform that provides endpoint protection, threat intelligence, and incident response powered by AI.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
+    ]
+  },
+  {
+    "name": "Fortinet",
+    "url": "https://www.fortinet.com/",
+    "description": "Provides integrated cybersecurity solutions including next-gen firewalls, secure SD-WAN, and endpoint protection.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
     ]
   },
   {
@@ -738,9 +720,27 @@
     ]
   },
   {
+    "name": "Netskope",
+    "url": "https://www.netskope.com/",
+    "description": "A cloud-native security platform that protects users, apps, and data with visibility and control across SaaS, IaaS, and the web.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
+    ]
+  },
+  {
     "name": "Ola Krutrim",
     "url": "https://www.olakrutrim.com/",
     "description": "Developing India's first sovereign AI cloud, offering scalable GPU-accelerated services and domestically designed AI chips to empower AI workloads.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
+    ]
+  },
+  {
+    "name": "Operant",
+    "url": "https://operant.ai/",
+    "description": "Provides runtime protection for cloud-native applications using graph-based detection and real-time observability.",
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
@@ -774,9 +774,27 @@
     ]
   },
   {
+    "name": "Wiz",
+    "url": "https://www.wiz.io/",
+    "description": "A cloud security platform that gives full-stack visibility into cloud infrastructure and prioritizes risk across workloads, containers, and identities.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
+    ]
+  },
+  {
     "name": "Yotta",
     "url": "https://yotta.com/blog-need-of-sovereign-cloud-in-india/",
     "description": "Indian data center and cloud services provider focusing on security, compliance, and innovation.",
+    "score": 3,
+    "categories": [
+      "Security, Compliance & Sovereignty Clouds"
+    ]
+  },
+  {
+    "name": "Zscaler",
+    "url": "https://www.zscaler.com/",
+    "description": "Zero trust SASE platform with AI-driven cybersecurity and cloud protection.",
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
@@ -810,24 +828,6 @@
     ]
   },
   {
-    "name": "Puter",
-    "url": "https://puter.com/",
-    "description": "A privacy-first personal cloud that houses all your files, apps, and games in one secure place, accessible from anywhere at any time.",
-    "score": 3,
-    "categories": [
-      "Unikernels & WebAssembly"
-    ]
-  },
-  {
-    "name": "SingleStore",
-    "url": "https://www.singlestore.com/",
-    "description": "Real-time database combining transactions and analytics with vector search capabilities.",
-    "score": 3,
-    "categories": [
-      "Unikernels & WebAssembly"
-    ]
-  },
-  {
     "name": "Wasmer",
     "url": "https://wasmer.io/",
     "description": "Offers a universal WebAssembly runtime that enables running applications safely and efficiently across various platforms, from desktop to cloud and edge.",
@@ -837,9 +837,9 @@
     ]
   },
   {
-    "name": "Airbyte",
-    "url": "https://airbyte.com/",
-    "description": "Open-source data integration platform with 600+ connectors and CDK for custom integrations.",
+    "name": "Aiven",
+    "url": "https://aiven.io/",
+    "description": "Offers managed open-source data infrastructure, including databases and messaging systems, on all major clouds.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -855,81 +855,9 @@
     ]
   },
   {
-    "name": "Arroyo",
-    "url": "https://arroyo.dev",
-    "description": "Provides cloud-native stream processing engine built in Rust that enables real-time data transformation, filtering, aggregation, and joins using SQL with sub-second results.",
-    "score": 2,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Storadera",
-    "url": "https://storaderacom.com/",
-    "description": "European S3 compatible cloud storage with predictable pricing, no egress fees, and multi-region infrastructure for backup, AI, and cloud workloads.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Aiven",
-    "url": "https://aiven.io/",
-    "description": "Offers managed open-source data infrastructure, including databases and messaging systems, on all major clouds.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Amplitude",
-    "url": "https://amplitude.com/",
-    "description": "Provides product analytics to help teams understand user behavior and build better products.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "BetterStack",
-    "url": "https://betterstack.com/",
-    "description": "Combines monitoring, logging, and incident management into a single platform for developers.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "CedarDB",
     "url": "https://cedardb.com/",
     "description": "Modern columnar database for real-time analytics.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Checkly",
-    "url": "https://www.checklyhq.com/",
-    "description": "Application reliability platform unifying testing, monitoring, observability, and incident management with Playwright-based synthetic monitoring.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Chronosphere",
-    "url": "https://chronosphere.io/",
-    "description": "Delivers a scalable observability platform designed for cloud-native environments, helping teams control costs and improve reliability.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "ClickHouse",
-    "url": "https://clickhouse.com/",
-    "description": "An open-source, column-oriented OLAP database management system for real-time analytics using SQL queries.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -954,54 +882,9 @@
     ]
   },
   {
-    "name": "Comet",
-    "url": "https://www.comet.com/",
-    "description": "AI observability and evaluation platform with tracing, human annotation, and automated evaluation for LLM applications.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Coralogix",
-    "url": "https://coralogix.com/",
-    "description": "Ingest all your data, store it indefinitely on your cloud, and query across all types with a unified syntax.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Couchbase",
     "url": "https://www.couchbase.com/",
     "description": "Offers a distributed NoSQL cloud database for mission-critical applications.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Databricks",
-    "url": "https://www.databricks.com/",
-    "description": "Provides a unified analytics platform for big data and AI, built on Apache Spark.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Datadog",
-    "url": "https://www.datadoghq.com/",
-    "description": "A monitoring and security platform for cloud applications.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "dbt Labs",
-    "url": "https://www.getdbt.com/",
-    "description": "Empowers data practitioners to transform data in their warehouses by developing, testing, and documenting analytics code.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1026,78 +909,6 @@
     ]
   },
   {
-    "name": "Domo",
-    "url": "https://www.domo.com/",
-    "description": "Provides a cloud-based platform for business intelligence and data visualization.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "DuckDB",
-    "url": "https://duckdb.org/",
-    "description": "An in-process SQL OLAP database management system designed for fast analytical queries.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Dynatrace",
-    "url": "https://www.dynatrace.com/",
-    "description": "Offers a unified observability and security platform powered by AI, providing analytics and automation for multicloud environments.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Elastic",
-    "url": "https://www.elastic.co/",
-    "description": "Provides search-powered solutions for observability, security, and enterprise search.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Fathom",
-    "url": "https://usefathom.com/",
-    "description": "Privacy-focused web analytics platform offering real-time insights without cookies or invasive tracking.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Firebolt",
-    "url": "https://www.firebolt.io/",
-    "description": "Delivers a cloud data warehouse designed for high-performance analytics.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Fivetran",
-    "url": "https://www.fivetran.com/",
-    "description": "Automated data integration platform with 300+ connectors and zero-maintenance ETL pipelines.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "FullStory",
-    "url": "https://www.fullstory.com/",
-    "description": "Offers digital experience analytics to understand and improve user interactions.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Gel",
     "url": "https://www.geldata.com/",
     "description": "Next-generation graph-relational database with modern query language.",
@@ -1107,54 +918,9 @@
     ]
   },
   {
-    "name": "Grafana",
-    "url": "https://grafana.com/",
-    "description": "An open-source platform for monitoring and observability, enabling visualization of metrics, logs, and traces.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "groundcover",
-    "url": "https://www.groundcover.com/",
-    "description": "eBPF-based observability platform with BYOC architecture for logs, metrics, and traces.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Hasura",
     "url": "https://hasura.io/",
     "description": "Instantly generates GraphQL APIs over new or existing PostgresSQL databases.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Heap",
-    "url": "https://heap.io/",
-    "description": "Automatically captures user interactions to provide insights into user behavior without manual tracking.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Honeycomb",
-    "url": "https://www.honeycomb.io/",
-    "description": "An observability platform that helps engineering teams understand, debug, and improve complex systems.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Highlight",
-    "url": "https://highlight.io/",
-    "description": "Open-source fullstack monitoring platform with session replay, error monitoring, logging, and traces.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1179,33 +945,6 @@
     ]
   },
   {
-    "name": "Kentik",
-    "url": "https://www.kentik.com/",
-    "description": "Provides network observability solutions for performance monitoring and security.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "LogRocket",
-    "url": "https://logrocket.com/",
-    "description": "Replays user sessions to help developers understand and fix issues faster.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Logz.io",
-    "url": "https://logz.io/",
-    "description": "Offers an open-source observability platform for monitoring, troubleshooting, and securing applications.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Materialize",
     "url": "https://materialize.com/",
     "description": "Streaming SQL database for real-time data transformation and analytics.",
@@ -1218,24 +957,6 @@
     "name": "Meilisearch",
     "url": "https://www.meilisearch.com/",
     "description": "Rust-based open-source search engine with hybrid search capabilities and typo-tolerant fast search.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Mezmo",
-    "url": "https://www.mezmo.com/",
-    "description": "Provides a central observability platform to control, enrich, and correlate machine data for faster business decisions.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Mixpanel",
-    "url": "https://mixpanel.com/",
-    "description": "Delivers product analytics to help teams build better products through data-driven decisions.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1260,15 +981,6 @@
     ]
   },
   {
-    "name": "MotherDuck",
-    "url": "https://motherduck.com/",
-    "description": "Serverless analytics platform powered by DuckDB with cloud collaboration.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Neo4j",
     "url": "https://neo4j.com/",
     "description": "A graph database platform for connected data applications.",
@@ -1287,45 +999,9 @@
     ]
   },
   {
-    "name": "New Relic",
-    "url": "https://newrelic.com/",
-    "description": "An observability platform that unifies metrics, events, logs, and traces for full-stack monitoring.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "OpenStatus",
-    "url": "https://www.openstatus.dev/",
-    "description": "Open-source status page and monitoring platform for tracking API and website uptime worldwide.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Planetscale",
     "url": "https://planetscale.com/",
     "description": "A serverless database platform built on Vitess, offering scalability and reliability for MySQL databases.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Plausible",
-    "url": "https://plausible.io/",
-    "description": "Lightweight, privacy-focused web analytics platform without cookies, offering essential metrics in an intuitive dashboard.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "PostHog",
-    "url": "https://posthog.com/",
-    "description": "An open-source product analytics platform that can be deployed on-premises.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1359,15 +1035,6 @@
     ]
   },
   {
-    "name": "Redpanda",
-    "url": "https://www.redpanda.com/",
-    "description": "Kafka-compatible streaming data platform with built-in identity controls and policy enforcement for AI workloads.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Redis",
     "url": "https://redis.io/",
     "description": "An in-memory data structure store used as a database, cache, and message broker.",
@@ -1377,36 +1044,9 @@
     ]
   },
   {
-    "name": "Rivery",
-    "url": "https://rivery.io/",
-    "description": "No-code data integration platform with visual workflows and 150+ connectors with built-in transformations.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Sentry",
-    "url": "https://sentry.io/",
-    "description": "Application monitoring platform for error tracking, performance monitoring, and session replay to identify and resolve code issues.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Snowflake",
-    "url": "https://www.snowflake.com/en/",
-    "description": "A cloud data platform offering data warehousing, data lakes, and data sharing capabilities.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Splunk",
-    "url": "https://www.splunk.com/",
-    "description": "Provides a platform for searching, monitoring, and analyzing machine-generated big data.",
+    "name": "SingleStore",
+    "url": "https://www.singlestore.com/",
+    "description": "Real-time database combining transactions and analytics with vector search capabilities.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1431,15 +1071,6 @@
     ]
   },
   {
-    "name": "Sumo Logic",
-    "url": "https://www.sumologic.com/",
-    "description": "Offers cloud-native machine data analytics for real-time insights into operations and security.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Supabase",
     "url": "https://supabase.com/",
     "description": "An open-source Firebase alternative that provides a backend-as-a-service.",
@@ -1458,15 +1089,6 @@
     ]
   },
   {
-    "name": "Teradata",
-    "url": "https://www.teradata.com/",
-    "description": "Specializing in providing solutions for data warehousing, analytics, and big data analytics.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "TigerData",
     "url": "https://www.tigerdata.com/",
     "description": "PostgreSQL-based time-series database with compression and continuous aggregates.",
@@ -1479,15 +1101,6 @@
     "name": "Tigris",
     "url": "https://www.tigrisdata.com/",
     "description": "A globally distributed S3-compatible object storage service that enables developers to store and access any amount of data.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
-    "name": "Tinybird",
-    "url": "https://www.tinybird.co/",
-    "description": "Real-time data platform for building instant APIs over streaming and batch data.",
     "score": 3,
     "categories": [
       "Databases & Storage"
@@ -1530,21 +1143,435 @@
     ]
   },
   {
-    "name": "Weights & Biases",
-    "url": "https://wandb.ai/",
-    "description": "AI developer platform for experiment tracking, model management, evaluation, and observability for ML and LLM applications.",
-    "score": 3,
-    "categories": [
-      "Databases & Storage"
-    ]
-  },
-  {
     "name": "Xata",
     "url": "https://xata.io/",
     "description": "Serverless database platform with built-in search and analytics.",
     "score": 3,
     "categories": [
       "Databases & Storage"
+    ]
+  },
+  {
+    "name": "Amplitude",
+    "url": "https://amplitude.com/",
+    "description": "Provides product analytics to help teams understand user behavior and build better products.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "ClickHouse",
+    "url": "https://clickhouse.com/",
+    "description": "An open-source, column-oriented OLAP database management system for real-time analytics using SQL queries.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Databricks",
+    "url": "https://www.databricks.com/",
+    "description": "Provides a unified analytics platform for big data and AI, built on Apache Spark.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Domo",
+    "url": "https://www.domo.com/",
+    "description": "Provides a cloud-based platform for business intelligence and data visualization.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "DuckDB",
+    "url": "https://duckdb.org/",
+    "description": "An in-process SQL OLAP database management system designed for fast analytical queries.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Fathom",
+    "url": "https://usefathom.com/",
+    "description": "Privacy-focused web analytics platform offering real-time insights without cookies or invasive tracking.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Firebolt",
+    "url": "https://www.firebolt.io/",
+    "description": "Delivers a cloud data warehouse designed for high-performance analytics.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "FullStory",
+    "url": "https://www.fullstory.com/",
+    "description": "Offers digital experience analytics to understand and improve user interactions.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Heap",
+    "url": "https://heap.io/",
+    "description": "Automatically captures user interactions to provide insights into user behavior without manual tracking.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Mixpanel",
+    "url": "https://mixpanel.com/",
+    "description": "Delivers product analytics to help teams build better products through data-driven decisions.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "MotherDuck",
+    "url": "https://motherduck.com/",
+    "description": "Serverless analytics platform powered by DuckDB with cloud collaboration.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Plausible",
+    "url": "https://plausible.io/",
+    "description": "Lightweight, privacy-focused web analytics platform without cookies, offering essential metrics in an intuitive dashboard.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "PostHog",
+    "url": "https://posthog.com/",
+    "description": "An open-source product analytics platform that can be deployed on-premises.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Snowflake",
+    "url": "https://www.snowflake.com/en/",
+    "description": "A cloud data platform offering data warehousing, data lakes, and data sharing capabilities.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Teradata",
+    "url": "https://www.teradata.com/",
+    "description": "Specializing in providing solutions for data warehousing, analytics, and big data analytics.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "Tinybird",
+    "url": "https://www.tinybird.co/",
+    "description": "Real-time data platform for building instant APIs over streaming and batch data.",
+    "score": 3,
+    "categories": [
+      "Analytics & Data Warehousing"
+    ]
+  },
+  {
+    "name": "BetterStack",
+    "url": "https://betterstack.com/",
+    "description": "Combines monitoring, logging, and incident management into a single platform for developers.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Checkly",
+    "url": "https://www.checklyhq.com/",
+    "description": "Application reliability platform unifying testing, monitoring, observability, and incident management with Playwright-based synthetic monitoring.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Chronosphere",
+    "url": "https://chronosphere.io/",
+    "description": "Delivers a scalable observability platform designed for cloud-native environments, helping teams control costs and improve reliability.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Comet",
+    "url": "https://www.comet.com/",
+    "description": "AI observability and evaluation platform with tracing, human annotation, and automated evaluation for LLM applications.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Coralogix",
+    "url": "https://coralogix.com/",
+    "description": "Ingest all your data, store it indefinitely on your cloud, and query across all types with a unified syntax.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Datadog",
+    "url": "https://www.datadoghq.com/",
+    "description": "A monitoring and security platform for cloud applications.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Dynatrace",
+    "url": "https://www.dynatrace.com/",
+    "description": "Offers a unified observability and security platform powered by AI, providing analytics and automation for multicloud environments.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Elastic",
+    "url": "https://www.elastic.co/",
+    "description": "Provides search-powered solutions for observability, security, and enterprise search.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Gigapipe",
+    "url": "https://gigapipe.com/",
+    "description": "Provides unified polyglot observability platform for logs, metrics, traces and profiles with drop-in compatibility for Loki, Prometheus, Tempo, and Pyroscope.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Grafana",
+    "url": "https://grafana.com/",
+    "description": "An open-source platform for monitoring and observability, enabling visualization of metrics, logs, and traces.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "groundcover",
+    "url": "https://www.groundcover.com/",
+    "description": "eBPF-based observability platform with BYOC architecture for logs, metrics, and traces.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Helicone",
+    "url": "https://www.helicone.ai/",
+    "description": "Open-source LLM observability and monitoring platform.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Highlight",
+    "url": "https://highlight.io/",
+    "description": "Open-source fullstack monitoring platform with session replay, error monitoring, logging, and traces.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Honeycomb",
+    "url": "https://www.honeycomb.io/",
+    "description": "An observability platform that helps engineering teams understand, debug, and improve complex systems.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Kentik",
+    "url": "https://www.kentik.com/",
+    "description": "Provides network observability solutions for performance monitoring and security.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Laminar",
+    "url": "https://laminar.sh/",
+    "description": "Observability and analytics platform for LLM applications.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "LogRocket",
+    "url": "https://logrocket.com/",
+    "description": "Replays user sessions to help developers understand and fix issues faster.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Logz.io",
+    "url": "https://logz.io/",
+    "description": "Offers an open-source observability platform for monitoring, troubleshooting, and securing applications.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Mezmo",
+    "url": "https://www.mezmo.com/",
+    "description": "Provides a central observability platform to control, enrich, and correlate machine data for faster business decisions.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "New Relic",
+    "url": "https://newrelic.com/",
+    "description": "An observability platform that unifies metrics, events, logs, and traces for full-stack monitoring.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "OpenStatus",
+    "url": "https://www.openstatus.dev/",
+    "description": "Open-source status page and monitoring platform for tracking API and website uptime worldwide.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Sentry",
+    "url": "https://sentry.io/",
+    "description": "Application monitoring platform for error tracking, performance monitoring, and session replay to identify and resolve code issues.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Splunk",
+    "url": "https://www.splunk.com/",
+    "description": "Provides a platform for searching, monitoring, and analyzing machine-generated big data.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Sumo Logic",
+    "url": "https://www.sumologic.com/",
+    "description": "Offers cloud-native machine data analytics for real-time insights into operations and security.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Weights & Biases",
+    "url": "https://wandb.ai/",
+    "description": "AI developer platform for experiment tracking, model management, evaluation, and observability for ML and LLM applications.",
+    "score": 3,
+    "categories": [
+      "Observability & Monitoring"
+    ]
+  },
+  {
+    "name": "Airbyte",
+    "url": "https://airbyte.com/",
+    "description": "Open-source data integration platform with 600+ connectors and CDK for custom integrations.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
+    ]
+  },
+  {
+    "name": "Arroyo",
+    "url": "https://arroyo.dev",
+    "description": "Provides cloud-native stream processing engine built in Rust that enables real-time data transformation, filtering, aggregation, and joins using SQL with sub-second results.",
+    "score": 2,
+    "categories": [
+      "Data Integration & ETL"
+    ]
+  },
+  {
+    "name": "dbt Labs",
+    "url": "https://www.getdbt.com/",
+    "description": "Empowers data practitioners to transform data in their warehouses by developing, testing, and documenting analytics code.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
+    ]
+  },
+  {
+    "name": "Fivetran",
+    "url": "https://www.fivetran.com/",
+    "description": "Automated data integration platform with 300+ connectors and zero-maintenance ETL pipelines.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
+    ]
+  },
+  {
+    "name": "Redpanda",
+    "url": "https://www.redpanda.com/",
+    "description": "Kafka-compatible streaming data platform with built-in identity controls and policy enforcement for AI workloads.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
+    ]
+  },
+  {
+    "name": "Rivery",
+    "url": "https://rivery.io/",
+    "description": "No-code data integration platform with visual workflows and 150+ connectors with built-in transformations.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
     ]
   },
   {
@@ -1719,15 +1746,6 @@
     ]
   },
   {
-    "name": "Boundary",
-    "url": "https://www.boundaryproject.io/",
-    "description": "HashiCorp's secure remote access to systems and services.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
     "name": "c/Side",
     "url": "https://cside.dev/",
     "description": "A next generation web security service that monitors, optimizes and secures 3rd party scripts.",
@@ -1755,15 +1773,6 @@
     ]
   },
   {
-    "name": "CrowdStrike",
-    "url": "https://www.crowdstrike.com/",
-    "description": "A cloud-native cybersecurity platform that provides endpoint protection, threat intelligence, and incident response powered by AI.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
     "name": "CtrlDNS",
     "url": "https://www.ctrldns.com/",
     "description": "Provides DNS management and control services for domain name resolution and network infrastructure management.",
@@ -1776,15 +1785,6 @@
     "name": "Fastly",
     "url": "https://www.fastly.com/",
     "description": "An edge cloud platform designed for performance and security, enabling developers to build faster, more secure digital experiences.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
-    "name": "Fortinet",
-    "url": "https://www.fortinet.com/",
-    "description": "Provides integrated cybersecurity solutions including next-gen firewalls, secure SD-WAN, and endpoint protection.",
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
@@ -1854,45 +1854,9 @@
     ]
   },
   {
-    "name": "Netskope",
-    "url": "https://www.netskope.com/",
-    "description": "A cloud-native security platform that protects users, apps, and data with visibility and control across SaaS, IaaS, and the web.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
-    "name": "Operant",
-    "url": "https://operant.ai/",
-    "description": "Provides runtime protection for cloud-native applications using graph-based detection and real-time observability.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
     "name": "Pangolin",
     "url": "https://digpangolin.com/",
     "description": "Secure app exposure via WireGuard tunnels with identity-aware access control.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
-    "name": "Pomerium",
-    "url": "https://www.pomerium.com/",
-    "description": "Identity-aware access proxy for securing internal apps.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
-    "name": "StrongDM",
-    "url": "https://www.strongdm.com/",
-    "description": "Zero-trust access platform for infrastructure and databases.",
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
@@ -1917,15 +1881,6 @@
     ]
   },
   {
-    "name": "Teleport",
-    "url": "https://goteleport.com/",
-    "description": "Zero trust infrastructure access platform with cryptographic identity and least privileged access.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
     "name": "Twingate",
     "url": "https://www.twingate.com/",
     "description": "Provides a modern zero-trust networking solution to securely connect people to private apps and services without VPNs.",
@@ -1938,15 +1893,6 @@
     "name": "Versa Networks",
     "url": "https://www.versa-networks.com/",
     "description": "Delivers integrated SASE and SD-WAN solutions for secure, scalable, and simplified enterprise networking.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
-    "name": "Wiz",
-    "url": "https://www.wiz.io/",
-    "description": "A cloud security platform that gives full-stack visibility into cloud infrastructure and prioritizes risk across workloads, containers, and identities.",
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
@@ -1971,19 +1917,37 @@
     ]
   },
   {
-    "name": "Zscaler",
-    "url": "https://www.zscaler.com/",
-    "description": "Zero trust SASE platform with AI-driven cybersecurity and cloud protection.",
-    "score": 3,
-    "categories": [
-      "Network & Connectivity Clouds"
-    ]
-  },
-  {
     "name": "Anchor",
     "url": "https://anchorbrowser.io/",
     "description": "Provides AI-powered browser automation infrastructure with humanized Chromium instances that can access any website, handle authentication, and perform web tasks reliably.",
     "score": 2,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "Fireworks.ai",
+    "url": "https://fireworks.ai/",
+    "description": "Delivers high-speed, cost-effective inference APIs with support for open-source models.",
+    "score": 3,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "Groq",
+    "url": "https://groq.com/",
+    "description": "Provides ultra-fast inference on custom hardware designed for AI workloads.",
+    "score": 3,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "LeptonAI",
+    "url": "https://lepton.ai/",
+    "description": "Provides infrastructure and tools to build and deploy AI models at scale.",
+    "score": 3,
     "categories": [
       "AI Inference & Model APIs"
     ]
@@ -1998,18 +1962,45 @@
     ]
   },
   {
-    "name": "AssemblyAI",
-    "url": "https://www.assemblyai.com/",
-    "description": "Offers powerful speech-to-text and AI APIs for transcription, summarization, content moderation, and more.",
+    "name": "Portkey",
+    "url": "https://portkey.ai/",
+    "description": "AI Gateway control panel for production apps with unified gateway to 1600+ LLMs, observability, guardrails, and governance. OpenAI-compatible with semantic caching and SOC2/HIPAA/GDPR compliance.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ]
   },
   {
-    "name": "Base44",
-    "url": "https://base44.com/",
-    "description": "An all-in-one AI platform to easily build fully functioning apps without coding.",
+    "name": "Replicate",
+    "url": "https://replicate.com/",
+    "description": "Run machine learning models in the cloud with an API.",
+    "score": 3,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "Roboflow",
+    "url": "https://roboflow.com/",
+    "description": "Offers tools for building and deploying computer vision models, simplifying data collection, annotation, and model training for developers.",
+    "score": 3,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "Together.ai",
+    "url": "https://www.together.ai/",
+    "description": "Open-source foundation model infrastructure with collaborative fine-tuning.",
+    "score": 3,
+    "categories": [
+      "AI Inference & Model APIs"
+    ]
+  },
+  {
+    "name": "AssemblyAI",
+    "url": "https://www.assemblyai.com/",
+    "description": "Offers powerful speech-to-text and AI APIs for transcription, summarization, content moderation, and more.",
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
@@ -2061,15 +2052,6 @@
     ]
   },
   {
-    "name": "Codev",
-    "url": "https://codev.ai/",
-    "description": "A development assistant that uses AI to generate, analyze, and debug software code efficiently.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
     "name": "Cohere",
     "url": "https://cohere.com/",
     "description": "Enterprise AI platform with language models for automation, data insights, and custom solutions.",
@@ -2097,15 +2079,6 @@
     ]
   },
   {
-    "name": "E2B",
-    "url": "https://e2b.dev/",
-    "description": "Secure sandboxes for AI code execution with filesystem, networking, and long-running process support for AI agents.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
     "name": "ElevenLabs",
     "url": "https://elevenlabs.io/",
     "description": "AI text-to-speech with ultra-realistic voices in 32+ languages, voice cloning, and conversational agents.",
@@ -2124,54 +2097,9 @@
     ]
   },
   {
-    "name": "Fireworks.ai",
-    "url": "https://fireworks.ai/",
-    "description": "Delivers high-speed, cost-effective inference APIs with support for open-source models.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Gadget",
-    "url": "https://gadget.dev/",
-    "description": "Full-stack framework with built-in database, auth, and deployment.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "GitHub Copilot",
-    "url": "https://github.com/features/copilot",
-    "description": "An AI-powered coding assistant developed by GitHub and OpenAI that suggests code snippets as you type.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Groq",
-    "url": "https://groq.com/",
-    "description": "Provides ultra-fast inference on custom hardware designed for AI workloads.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Helicone",
-    "url": "https://www.helicone.ai/",
-    "description": "Open-source LLM observability and monitoring platform.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Laminar",
-    "url": "https://laminar.sh/",
-    "description": "Observability and analytics platform for LLM applications.",
+    "name": "Kimi AI",
+    "url": "https://www.kimi.com",
+    "description": "Provides AI-powered conversational assistance with visual coding capabilities, agent swarm technology, and deep research tools for enhanced productivity.",
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
@@ -2181,33 +2109,6 @@
     "name": "Layer 9",
     "url": "https://layer9.com/",
     "description": "AI network engineer that configures, monitors, and repairs network devices with 24/7 automation.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "LeptonAI",
-    "url": "https://lepton.ai/",
-    "description": "Provides infrastructure and tools to build and deploy AI models at scale.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Lightning.ai",
-    "url": "https://lightning.ai/",
-    "description": "Build, train, and deploy AI models with powerful tools and scalable infrastructure.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Marblism",
-    "url": "https://www.marblism.com/",
-    "description": "Generate full-stack web apps from a single prompt.",
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
@@ -2259,33 +2160,6 @@
     ]
   },
   {
-    "name": "Prismic",
-    "url": "https://prismic.io/",
-    "description": "A headless CMS for developers to build and manage dynamic websites using modern frameworks and custom content APIs.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Replicate",
-    "url": "https://replicate.com/",
-    "description": "Run machine learning models in the cloud with an API.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Replit",
-    "url": "https://replit.com/",
-    "description": "Collaborative browser IDE with instant deployment and multiplayer coding.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
     "name": "Resolve.ai",
     "url": "https://resolve.ai/",
     "description": "An agentic AI SRE from the co-creators of OpenTelemetry.",
@@ -2295,28 +2169,10 @@
     ]
   },
   {
-    "name": "Retool",
-    "url": "https://retool.com/",
-    "description": "A low-code platform to build custom internal tools quickly with pre-built components and database integrations.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "Softgen",
-    "url": "https://softgen.ai/",
-    "description": "Provides tools to automatically generate code, documentation, and tests to speed up software delivery.",
-    "score": 3,
-    "categories": [
-      "AI Assistants & Copilots"
-    ]
-  },
-  {
-    "name": "StackBlitz",
-    "url": "https://stackblitz.com/",
-    "description": "Instant full-stack dev environments running entirely in the browser.",
-    "score": 3,
+    "name": "SharonAI",
+    "url": "https://sharonai.com/en/",
+    "description": "Provides AI-powered solutions and services for business automation and intelligent decision-making processes.",
+    "score": 2,
     "categories": [
       "AI Assistants & Copilots"
     ]
@@ -2349,30 +2205,48 @@
     ]
   },
   {
-    "name": "Together.ai",
-    "url": "https://www.together.ai/",
-    "description": "Open-source foundation model infrastructure with collaborative fine-tuning.",
+    "name": "Base44",
+    "url": "https://base44.com/",
+    "description": "An all-in-one AI platform to easily build fully functioning apps without coding.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Coding & App Generation"
     ]
   },
   {
-    "name": "v0",
-    "url": "https://v0.app/",
-    "description": "AI-powered UI generation from text prompts to React code.",
+    "name": "Bolt",
+    "url": "https://bolt.new/",
+    "description": "A browser-based AI development environment that lets you generate, edit, and deploy full-stack applications instantly using natural language prompts.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Coding & App Generation"
     ]
   },
   {
-    "name": "Windsurf",
-    "url": "https://windsurf.com/",
-    "description": "An AI powered coding engine and IDE that is an alternative to GitHub Copilot. Formerly Codeium.",
+    "name": "Codev",
+    "url": "https://codev.ai/",
+    "description": "A development assistant that uses AI to generate, analyze, and debug software code efficiently.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "CopilotKit",
+    "url": "https://www.copilotkit.ai/",
+    "description": "Open-source framework and infrastructure for building in-app AI copilots and agents.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Cursor",
+    "url": "https://www.cursor.so/",
+    "description": "An AI-enhanced code editor that integrates directly with your codebase to provide suggestions and automate changes.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
     ]
   },
   {
@@ -2380,6 +2254,33 @@
     "url": "https://usegitai.com/",
     "description": "Provides open-source Git extension for tracking AI-generated code through the entire software development lifecycle with attribution, context storage, and team analytics.",
     "score": 2,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "GitHub Copilot",
+    "url": "https://github.com/features/copilot",
+    "description": "An AI-powered coding assistant developed by GitHub and OpenAI that suggests code snippets as you type.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Marblism",
+    "url": "https://www.marblism.com/",
+    "description": "Generate full-stack web apps from a single prompt.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Mesa",
+    "url": "https://www.mesa.dev",
+    "description": "AI-powered code review platform with custom agents that learn codebase standards and prevent tech debt.",
+    "score": 3,
     "categories": [
       "AI Coding & App Generation"
     ]
@@ -2394,6 +2295,177 @@
     ]
   },
   {
+    "name": "Softgen",
+    "url": "https://softgen.ai/",
+    "description": "Provides tools to automatically generate code, documentation, and tests to speed up software delivery.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Tabnine",
+    "url": "https://www.tabnine.com/",
+    "description": "AI code assistant with private model options.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "v0",
+    "url": "https://v0.app/",
+    "description": "AI-powered UI generation from text prompts to React code.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Windsurf",
+    "url": "https://windsurf.com/",
+    "description": "An AI powered coding engine and IDE that is an alternative to GitHub Copilot. Formerly Codeium.",
+    "score": 3,
+    "categories": [
+      "AI Coding & App Generation"
+    ]
+  },
+  {
+    "name": "Deno Deploy",
+    "url": "https://deno.com/deploy",
+    "description": "Globally distributed edge platform for JavaScript and TypeScript serverless apps.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Flightcontrol",
+    "url": "https://www.flightcontrol.dev/",
+    "description": "Automates infrastructure provisioning, CI/CD, and deployments within your own AWS account, offering full visibility and control.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Fly",
+    "url": "https://fly.io",
+    "description": "Provides a platform to deploy applications globally with low latency.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Gadget",
+    "url": "https://gadget.dev/",
+    "description": "Full-stack framework with built-in database, auth, and deployment.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Heroku",
+    "url": "https://www.heroku.com/",
+    "description": "Offers a platform as a service (PaaS) for deploying and managing applications.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Koyeb",
+    "url": "https://www.koyeb.com/",
+    "description": "Offers a serverless platform to deploy applications globally.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Netlify",
+    "url": "https://www.netlify.com/",
+    "description": "Platform for building, deploying, and scaling modern web applications.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Northflank",
+    "url": "https://northflank.com/",
+    "description": "A platform to build, deploy, and manage full-stack applications.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Pantheon",
+    "url": "https://pantheon.io/",
+    "description": "A platform for running Wordpress, Drupal and Next.js websites.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Platform.sh",
+    "url": "https://platform.sh/",
+    "description": "Enterprise PaaS to build, run, and scale web applications and microservices.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Porter",
+    "url": "https://porter.run/",
+    "description": "A Kubernetes-powered PaaS that runs in your own cloud provider, simplifying the deployment and management of applications on AWS, GCP, or Azure.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Puter",
+    "url": "https://puter.com/",
+    "description": "A privacy-first personal cloud that houses all your files, apps, and games in one secure place, accessible from anywhere at any time.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Railway",
+    "url": "https://railway.com/",
+    "description": "Deploy code instantly and manage environments in the cloud.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Render",
+    "url": "https://render.com/",
+    "description": "Unified cloud platform to build and host apps, websites, and agent workflows.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Shuttle",
+    "url": "https://www.shuttle.dev/",
+    "description": "Rust-native cloud platform for building and deploying backend services.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
     "name": "Skyhook",
     "url": "https://skyhook.io/",
     "description": "PaaS for deploying and managing Kubernetes clusters and workloads with GitOps support, preview environments, and AI assistance.",
@@ -2403,9 +2475,18 @@
     ]
   },
   {
-    "name": "Bolt",
-    "url": "https://bolt.new/",
-    "description": "A browser-based AI development environment that lets you generate, edit, and deploy full-stack applications instantly using natural language prompts.",
+    "name": "Upsun",
+    "url": "https://upsun.com/",
+    "description": "An application hosting platform from the team at Platform.sh.",
+    "score": 3,
+    "categories": [
+      "PaaS & Application Hosting"
+    ]
+  },
+  {
+    "name": "Browserbase",
+    "url": "https://www.browserbase.com/",
+    "description": "A platform for running headless browsers for interact with websites via automation.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2448,36 +2529,9 @@
     ]
   },
   {
-    "name": "CopilotKit",
-    "url": "https://www.copilotkit.ai/",
-    "description": "Open-source framework and infrastructure for building in-app AI copilots and agents.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Cursor",
-    "url": "https://www.cursor.so/",
-    "description": "An AI-enhanced code editor that integrates directly with your codebase to provide suggestions and automate changes.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
     "name": "Cypress",
     "url": "https://www.cypress.io/",
     "description": "Browser testing framework for modern web applications with AI-powered test generation and self-healing capabilities.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Deno Deploy",
-    "url": "https://deno.com/deploy",
-    "description": "Globally distributed edge platform for JavaScript and TypeScript serverless apps.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2511,6 +2565,15 @@
     ]
   },
   {
+    "name": "E2B",
+    "url": "https://e2b.dev/",
+    "description": "Secure sandboxes for AI code execution with filesystem, networking, and long-running process support for AI agents.",
+    "score": 3,
+    "categories": [
+      "Developer Tooling & CI/CD"
+    ]
+  },
+  {
     "name": "Fabrica",
     "url": "https://www.usefabrica.app/",
     "description": "AI platform that builds internal apps from prompts with database and tooling integrations.",
@@ -2538,54 +2601,9 @@
     ]
   },
   {
-    "name": "Flightcontrol",
-    "url": "https://www.flightcontrol.dev/",
-    "description": "Automates infrastructure provisioning, CI/CD, and deployments within your own AWS account, offering full visibility and control.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Fly",
-    "url": "https://fly.io",
-    "description": "Provides a platform to deploy applications globally with low latency.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
     "name": "Gammacode",
     "url": "https://gammacode.dev/",
     "description": "AI code intelligence platform with CLI/web interface, security scanning, and issue automation.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Gigapipe",
-    "url": "https://gigapipe.com/",
-    "description": "Provides unified polyglot observability platform for logs, metrics, traces and profiles with drop-in compatibility for Loki, Prometheus, Tempo, and Pyroscope.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "GitHub",
-    "url": "https://github.com/",
-    "description": "The world's leading platform for version control and collaboration, offering GitHub Codespaces for instant, cloud-based development environments.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "GitLab",
-    "url": "https://gitlab.com/",
-    "description": "Managed Git hosting with CI/CD and integrated privacy-first AI workflows.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2619,36 +2637,9 @@
     ]
   },
   {
-    "name": "Heroku",
-    "url": "https://www.heroku.com/",
-    "description": "Offers a platform as a service (PaaS) for deploying and managing applications.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
     "name": "JetBrains",
     "url": "https://www.jetbrains.com/",
     "description": "Intelligent development tools and IDEs including IntelliJ IDEA and Kotlin language.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Kimi AI",
-    "url": "https://www.kimi.com",
-    "description": "Provides AI-powered conversational assistance with visual coding capabilities, agent swarm technology, and deep research tools for enhanced productivity.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Koyeb",
-    "url": "https://www.koyeb.com/",
-    "description": "Offers a serverless platform to deploy applications globally.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2673,36 +2664,9 @@
     ]
   },
   {
-    "name": "Mesa",
-    "url": "https://www.mesa.dev",
-    "description": "AI-powered code review platform with custom agents that learn codebase standards and prevent tech debt.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
     "name": "Mintlify",
     "url": "https://mintlify.com/",
     "description": "Modern documentation platform with MDX support, API references, interactive components, and built-in search analytics.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Netlify",
-    "url": "https://www.netlify.com/",
-    "description": "Platform for building, deploying, and scaling modern web applications.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Northflank",
-    "url": "https://northflank.com/",
-    "description": "A platform to build, deploy, and manage full-stack applications.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2727,45 +2691,9 @@
     ]
   },
   {
-    "name": "Pantheon",
-    "url": "https://pantheon.io/",
-    "description": "A platform for running Wordpress, Drupal and Next.js websites.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Platform.sh",
-    "url": "https://platform.sh/",
-    "description": "Enterprise PaaS to build, run, and scale web applications and microservices.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Porter",
-    "url": "https://porter.run/",
-    "description": "A Kubernetes-powered PaaS that runs in your own cloud provider, simplifying the deployment and management of applications on AWS, GCP, or Azure.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Portkey",
-    "url": "https://portkey.ai/",
-    "description": "AI Gateway control panel for production apps with unified gateway to 1600+ LLMs, observability, guardrails, and governance. OpenAI-compatible with semantic caching and SOC2/HIPAA/GDPR compliance.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Railway",
-    "url": "https://railway.com/",
-    "description": "Deploy code instantly and manage environments in the cloud.",
+    "name": "Prismic",
+    "url": "https://prismic.io/",
+    "description": "A headless CMS for developers to build and manage dynamic websites using modern frameworks and custom content APIs.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2781,18 +2709,18 @@
     ]
   },
   {
-    "name": "Render",
-    "url": "https://render.com/",
-    "description": "Unified cloud platform to build and host apps, websites, and agent workflows.",
+    "name": "Replit",
+    "url": "https://replit.com/",
+    "description": "Collaborative browser IDE with instant deployment and multiplayer coding.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
     ]
   },
   {
-    "name": "Roboflow",
-    "url": "https://roboflow.com/",
-    "description": "Offers tools for building and deploying computer vision models, simplifying data collection, annotation, and model training for developers.",
+    "name": "Retool",
+    "url": "https://retool.com/",
+    "description": "A low-code platform to build custom internal tools quickly with pre-built components and database integrations.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2808,18 +2736,9 @@
     ]
   },
   {
-    "name": "Shuttle",
-    "url": "https://www.shuttle.dev/",
-    "description": "Rust-native cloud platform for building and deploying backend services.",
-    "score": 3,
-    "categories": [
-      "Developer Tooling & CI/CD"
-    ]
-  },
-  {
-    "name": "Tabnine",
-    "url": "https://www.tabnine.com/",
-    "description": "AI code assistant with private model options.",
+    "name": "StackBlitz",
+    "url": "https://stackblitz.com/",
+    "description": "Instant full-stack dev environments running entirely in the browser.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2856,6 +2775,15 @@
     "name": "Unleash",
     "url": "https://www.getunleash.io/",
     "description": "Enterprise open-source feature management platform with strong RBAC and flexible deployment options.",
+    "score": 3,
+    "categories": [
+      "Developer Tooling & CI/CD"
+    ]
+  },
+  {
+    "name": "Warp",
+    "url": "https://www.warp.dev/",
+    "description": "Cloud service provider.",
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
@@ -2901,6 +2829,15 @@
     "name": "Bolster",
     "url": "https://bolster.ai/",
     "description": "A platform for preventing and mitigrating phishing and impersonation scams.",
+    "score": 3,
+    "categories": [
+      "Authorization, Identity & Fraud"
+    ]
+  },
+  {
+    "name": "Boundary",
+    "url": "https://www.boundaryproject.io/",
+    "description": "HashiCorp's secure remote access to systems and services.",
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
@@ -3051,6 +2988,15 @@
     ]
   },
   {
+    "name": "Pomerium",
+    "url": "https://www.pomerium.com/",
+    "description": "Identity-aware access proxy for securing internal apps.",
+    "score": 3,
+    "categories": [
+      "Authorization, Identity & Fraud"
+    ]
+  },
+  {
     "name": "PropelAuth",
     "url": "https://www.propelauth.com/",
     "description": "B2B authentication and user management for multi-tenant apps.",
@@ -3069,10 +3015,28 @@
     ]
   },
   {
+    "name": "StrongDM",
+    "url": "https://www.strongdm.com/",
+    "description": "Zero-trust access platform for infrastructure and databases.",
+    "score": 3,
+    "categories": [
+      "Authorization, Identity & Fraud"
+    ]
+  },
+  {
     "name": "Stytch",
     "url": "https://stytch.com/",
     "description": "Provides APIs and SDKs for passwordless authentication, including email magic links, SMS passcodes, and biometrics.",
     "score": 2,
+    "categories": [
+      "Authorization, Identity & Fraud"
+    ]
+  },
+  {
+    "name": "Teleport",
+    "url": "https://goteleport.com/",
+    "description": "Zero trust infrastructure access platform with cryptographic identity and least privileged access.",
+    "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
     ]
@@ -3411,6 +3375,15 @@
     ]
   },
   {
+    "name": "api.video",
+    "url": "https://api.video/",
+    "description": "Developer-first video API for encoding, hosting, streaming.",
+    "score": 3,
+    "categories": [
+      "Communications, IoT & Media"
+    ]
+  },
+  {
     "name": "Gradium",
     "url": "https://gradium.ai/",
     "description": "Provides audio language models for natural, expressive, ultra-low latency voice interactions with text-to-speech and speech-to-text capabilities in multiple languages.",
@@ -3546,6 +3519,24 @@
     ]
   },
   {
+    "name": "GitHub",
+    "url": "https://github.com/",
+    "description": "The world's leading platform for version control and collaboration, offering GitHub Codespaces for instant, cloud-based development environments.",
+    "score": 3,
+    "categories": [
+      "Source Code Control"
+    ]
+  },
+  {
+    "name": "GitLab",
+    "url": "https://gitlab.com/",
+    "description": "Managed Git hosting with CI/CD and integrated privacy-first AI workflows.",
+    "score": 3,
+    "categories": [
+      "Source Code Control"
+    ]
+  },
+  {
     "name": "Edgeless Systems",
     "url": "https://www.edgeless.systems/",
     "description": "Confidential computing platform using TEEs for runtime encryption of AI and cloud workloads.",
@@ -3582,15 +3573,6 @@
     ]
   },
   {
-    "name": "Oxide Computer",
-    "url": "https://oxide.computer/",
-    "description": "Rack-scale cloud computer for on-premises with unified hardware/software, but sold as CapEx hardware (~$1M/rack) rather than usage-based cloud service.",
-    "score": 3,
-    "categories": [
-      "Emerging & Unverified Providers"
-    ]
-  },
-  {
     "name": "API7",
     "url": "https://api7.ai/",
     "description": "Commercial distribution of Apache APISIX with cloud offerings, pending pricing transparency verification.",
@@ -3609,45 +3591,9 @@
     ]
   },
   {
-    "name": "KrakenD",
-    "url": "https://www.krakend.io/",
-    "description": "High-performance API gateway, needs cloud pricing model verification.",
-    "score": 3,
-    "categories": [
-      "Emerging & Unverified Providers"
-    ]
-  },
-  {
-    "name": "OpenObserve",
-    "url": "https://openobserve.ai/",
-    "description": "Open-source observability platform, cloud service SLA needs verification.",
-    "score": 3,
-    "categories": [
-      "Emerging & Unverified Providers"
-    ]
-  },
-  {
-    "name": "Uptrace",
-    "url": "https://uptrace.dev/",
-    "description": "Distributed tracing and metrics platform built on OpenTelemetry, verification needed.",
-    "score": 3,
-    "categories": [
-      "Emerging & Unverified Providers"
-    ]
-  },
-  {
     "name": "Chroma",
     "url": "https://www.trychroma.com/",
     "description": "Open-source vector database, managed cloud service details need verification.",
-    "score": 3,
-    "categories": [
-      "Emerging & Unverified Providers"
-    ]
-  },
-  {
-    "name": "Turbopuffer",
-    "url": "https://turbopuffer.com/",
-    "description": "Vector database optimized for speed, service verification needed.",
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
@@ -3672,9 +3618,36 @@
     ]
   },
   {
+    "name": "KrakenD",
+    "url": "https://www.krakend.io/",
+    "description": "High-performance API gateway, needs cloud pricing model verification.",
+    "score": 3,
+    "categories": [
+      "Emerging & Unverified Providers"
+    ]
+  },
+  {
     "name": "LaunchDarkly",
     "url": "https://launchdarkly.com/",
     "description": "Industry-leading feature management with $20k-$120k/year pricing but no public transparency.",
+    "score": 3,
+    "categories": [
+      "Emerging & Unverified Providers"
+    ]
+  },
+  {
+    "name": "OpenObserve",
+    "url": "https://openobserve.ai/",
+    "description": "Open-source observability platform, cloud service SLA needs verification.",
+    "score": 3,
+    "categories": [
+      "Emerging & Unverified Providers"
+    ]
+  },
+  {
+    "name": "Oxide Computer",
+    "url": "https://oxide.computer/",
+    "description": "Rack-scale cloud computer for on-premises with unified hardware/software, but sold as CapEx hardware (~$1M/rack) rather than usage-based cloud service.",
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
@@ -3702,6 +3675,24 @@
     "name": "Tggl",
     "url": "https://tggl.io/",
     "description": "Feature flags platform, verification needed.",
+    "score": 3,
+    "categories": [
+      "Emerging & Unverified Providers"
+    ]
+  },
+  {
+    "name": "Turbopuffer",
+    "url": "https://turbopuffer.com/",
+    "description": "Vector database optimized for speed, service verification needed.",
+    "score": 3,
+    "categories": [
+      "Emerging & Unverified Providers"
+    ]
+  },
+  {
+    "name": "Uptrace",
+    "url": "https://uptrace.dev/",
+    "description": "Distributed tracing and metrics platform built on OpenTelemetry, verification needed.",
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -145,26 +145,78 @@ def fetch_page(url, timeout=15, retries=2):
     return None, None
 
 
+def _jina_markdown_to_soup(markdown_text, base_url):
+    """Convert Jina Reader markdown output into a BeautifulSoup object.
+
+    Jina's default (markdown) mode executes JavaScript and returns rendered
+    content, but as markdown — not HTML.  This helper extracts all markdown
+    links and builds a minimal HTML document so that the existing
+    ``find_link_matching`` / ``find_all('a')`` logic keeps working.
+    """
+    # Extract markdown links: [text](url)
+    links = re.findall(r'\[([^\]]*)\]\((https?://[^)]+)\)', markdown_text)
+
+    # Build minimal HTML with the extracted links + full text
+    html_parts = ['<html><body>']
+    for text, href in links:
+        html_parts.append(f'<a href="{href}">{text}</a>')
+    # Preserve full text so that get_text() searches (SLA, pricing indicators) work
+    html_parts.append(f'<div>{markdown_text}</div>')
+    html_parts.append('</body></html>')
+
+    return BeautifulSoup('\n'.join(html_parts), 'html.parser')
+
+
+def _soup_has_meaningful_content(soup):
+    """Return True if the soup contains real rendered content, not just an SPA shell."""
+    text = soup.get_text(strip=True)
+    links = soup.find_all('a', href=True)
+    # An empty SPA shell typically has very little visible text and no links.
+    # A real page has substantial text (>200 chars) and at least one link.
+    return len(text) > 200 and len(links) >= 1
+
+
 def fetch_page_with_fallback(url, timeout=15, retries=2):
     """Try Jina Reader first (renders JS, bypasses CDN blocks), then requests as fallback.
     Returns (soup, final_url, fetch_method)."""
-    # Stage 1: Jina Reader with HTML mode — renders JS and handles Cloudflare-protected sites.
-    # X-Return-Format: html ensures we get proper HTML with <a> tags for link detection,
-    # not the default markdown format which breaks find_all('a', href=True).
     jina_url = f"https://r.jina.ai/{url}"
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (compatible; awesome-alt-clouds-bot/1.0)',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'X-Return-Format': 'html',
-    }
+
+    # Stage 1a: Jina Reader in default markdown mode — actually executes JavaScript
+    # and returns rendered content.  HTML mode (X-Return-Format: html) returns the
+    # raw HTML *before* JS execution, which is an empty shell for SPAs.
     try:
-        response = requests.get(jina_url, headers=headers, timeout=timeout, allow_redirects=True)
+        md_headers = {
+            'User-Agent': 'Mozilla/5.0 (compatible; awesome-alt-clouds-bot/1.0)',
+            'Accept': 'text/plain',
+        }
+        response = requests.get(jina_url, headers=md_headers, timeout=timeout, allow_redirects=True)
+        response.raise_for_status()
+        if response.text and len(response.text) > 200:
+            soup = _jina_markdown_to_soup(response.text, url)
+            if _soup_has_meaningful_content(soup):
+                return soup, url, "jina"
+            else:
+                print(f"Jina markdown response too thin for {url}, trying HTML mode")
+    except Exception as e:
+        print(f"Jina Reader (markdown) failed for {url}: {e}")
+
+    # Stage 1b: Jina Reader in HTML mode — works well for static / server-rendered sites
+    try:
+        html_headers = {
+            'User-Agent': 'Mozilla/5.0 (compatible; awesome-alt-clouds-bot/1.0)',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'X-Return-Format': 'html',
+        }
+        response = requests.get(jina_url, headers=html_headers, timeout=timeout, allow_redirects=True)
         response.raise_for_status()
         if response.text and len(response.text) > 100:
             soup = BeautifulSoup(response.text, 'html.parser')
-            return soup, url, "jina"
+            if _soup_has_meaningful_content(soup):
+                return soup, url, "jina"
+            else:
+                print(f"Jina HTML response is an empty SPA shell for {url}, falling back")
     except Exception as e:
-        print(f"Jina Reader failed for {url}: {e}")
+        print(f"Jina Reader (HTML) failed for {url}: {e}")
 
     # Stage 2: direct requests scraper (cheaper but fails on JS-heavy / CDN-blocked sites)
     soup, final_url = fetch_page(url, timeout=timeout, retries=retries)
@@ -190,6 +242,32 @@ def find_link_matching(soup, base_url, patterns):
     return None
 
 
+def _probe_url(url, timeout=10):
+    """Try to fetch a URL and return (soup, final_url) if it returns 200."""
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        }
+        response = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True)
+        if response.status_code == 200 and len(response.text) > 200:
+            return BeautifulSoup(response.text, 'html.parser'), response.url
+    except Exception:
+        pass
+    return None, None
+
+
+def _check_pricing_indicators(soup):
+    """Return True if the page contains pricing indicators."""
+    text = soup.get_text().lower()
+    price_indicators = [
+        '$', '€', '£', '/month', '/mo', '/year', '/yr', '/hr',
+        'per hour', 'per month', 'per year', 'free tier', 'free plan',
+        'pay as you go', 'pay-as-you-go', 'usage-based',
+    ]
+    return any(indicator in text for indicator in price_indicators)
+
+
 def check_pricing_page(soup, base_url):
     """Check for transparent public pricing"""
     result = {
@@ -203,20 +281,60 @@ def check_pricing_page(soup, base_url):
 
     if pricing_url:
         pricing_soup, final_url = fetch_page(pricing_url)
+        if pricing_soup and _check_pricing_indicators(pricing_soup):
+            result['passed'] = True
+            result['evidence'] = f'Pricing page found at {final_url}'
+            return result
         if pricing_soup:
-            # Look for pricing indicators
-            text = pricing_soup.get_text().lower()
-            price_indicators = ['$', '€', '£', '/month', '/mo', '/year', '/hr', 'per hour', 'free tier', 'pay as you go']
+            result['evidence'] = 'Pricing page exists but no clear pricing found'
 
-            for indicator in price_indicators:
-                if indicator in text:
-                    result['passed'] = True
-                    result['evidence'] = f'Pricing page found at {final_url}'
-                    return result
+    # Fallback: check if the homepage itself contains pricing indicators
+    if soup and _check_pricing_indicators(soup):
+        result['passed'] = True
+        result['evidence'] = 'Pricing information found on homepage'
+        return result
 
-            result['evidence'] = f'Pricing page exists but no clear pricing found'
+    # Fallback: probe common pricing URL patterns directly
+    parsed = urlparse(base_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    for path in ['/pricing', '/plans', '/price', '/#pricing', '/#plans']:
+        probe_url = base + path
+        probe_soup, probe_final = _probe_url(probe_url)
+        if probe_soup and _check_pricing_indicators(probe_soup):
+            result['passed'] = True
+            result['evidence'] = f'Pricing page found at {probe_final}'
+            return result
 
     return result
+
+
+def _has_signup_indicators(soup):
+    """Return True if the page contains signup/self-service indicators."""
+    signup_patterns = [
+        'signup', 'sign-up', 'sign up', 'register', 'get started',
+        'start free', 'try free', 'try for free', 'create account',
+        'start building', 'get started free', 'free trial', 'start trial',
+        'sign in', 'log in', 'login', 'signin',
+    ]
+
+    # Check links and buttons
+    for a in soup.find_all(['a', 'button']):
+        text = a.get_text().lower().strip()
+        href = a.get('href', '').lower()
+        for pattern in signup_patterns:
+            if pattern in text or pattern in href:
+                return True
+
+    # Check forms
+    for form in soup.find_all('form'):
+        form_text = form.get_text().lower()
+        if any(p in form_text for p in ['email', 'sign up', 'register', 'password']):
+            return True
+
+    # Check full page text as last resort (for Jina markdown-converted pages)
+    text = soup.get_text().lower()
+    strong_signals = ['sign up', 'create account', 'start free trial', 'get started free', 'try for free']
+    return any(signal in text for signal in strong_signals)
 
 
 def check_self_service(soup, base_url):
@@ -227,29 +345,23 @@ def check_self_service(soup, base_url):
         'evidence': 'No self-service signup found'
     }
 
-    signup_patterns = ['signup', 'sign-up', 'register', 'get started', 'start free', 'try free', 'create account']
-
     if not soup:
         return result
 
-    # Check for signup links/buttons
-    for a in soup.find_all(['a', 'button']):
-        text = a.get_text().lower()
-        href = a.get('href', '').lower()
+    if _has_signup_indicators(soup):
+        result['passed'] = True
+        result['evidence'] = 'Self-service signup available'
+        return result
 
-        for pattern in signup_patterns:
-            if pattern in text or pattern in href:
-                result['passed'] = True
-                result['evidence'] = f'Self-service signup available'
-                return result
-
-    # Check for signup forms
-    forms = soup.find_all('form')
-    for form in forms:
-        form_text = form.get_text().lower()
-        if any(p in form_text for p in ['email', 'sign up', 'register']):
+    # Fallback: probe common signup URL patterns
+    parsed = urlparse(base_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    for path in ['/signup', '/sign-up', '/register', '/login', '/signin']:
+        probe_soup, probe_final = _probe_url(base + path)
+        if probe_soup:
+            # A 200 on a signup/login page is strong evidence
             result['passed'] = True
-            result['evidence'] = 'Signup form found on homepage'
+            result['evidence'] = f'Signup page found at {probe_final}'
             return result
 
     return result

--- a/tests/test_evaluate_submission.py
+++ b/tests/test_evaluate_submission.py
@@ -39,11 +39,20 @@ class TestFetchPageWithFallback:
         assert method == 'requests'
 
     def test_falls_back_to_jina_when_requests_fails(self):
-        html = '<html><body><a href="/pricing">Pricing $9/mo</a><p>Sign up today for cloud infrastructure services with transparent pricing.</p></body></html>'
+        # Jina markdown mode returns rendered content with markdown links
+        markdown = (
+            'Title: Example Cloud\n\n'
+            'URL Source: https://example.com\n\n'
+            'Markdown Content:\n'
+            'Welcome to Example Cloud. We provide infrastructure services.\n'
+            '[Pricing](https://example.com/pricing) starts at $9/mo.\n'
+            '[Sign up](https://example.com/signup) today for transparent pricing.\n'
+            'Our platform offers reliable cloud infrastructure with guaranteed uptime.\n'
+        )
 
         def side_effect(url, **kwargs):
             if 'r.jina.ai' in url:
-                return _make_response(html)
+                return _make_response(markdown)
             raise requests.exceptions.ConnectionError('blocked')
 
         with patch('requests.get', side_effect=side_effect):
@@ -75,21 +84,22 @@ class TestFetchPageWithFallback:
 
         assert any('r.jina.ai' in u and 'example.com' in u for u in captured)
 
-    def test_jina_sends_html_format_header(self):
-        """Jina must request HTML (not markdown) so <a> tag link detection works."""
-        captured_kwargs = []
+    def test_jina_tries_markdown_mode_first(self):
+        """Jina markdown mode (which renders JS) should be tried before HTML mode."""
+        captured_calls = []
 
         def side_effect(url, **kwargs):
             if 'r.jina.ai' in url:
-                captured_kwargs.append(kwargs)
+                headers = kwargs.get('headers', {})
+                mode = 'html' if headers.get('X-Return-Format') == 'html' else 'markdown'
+                captured_calls.append(mode)
             raise requests.exceptions.ConnectionError('blocked')
 
         with patch('requests.get', side_effect=side_effect):
             ev.fetch_page_with_fallback('https://example.com')
 
-        assert captured_kwargs, "Jina was never called"
-        headers = captured_kwargs[0].get('headers', {})
-        assert headers.get('X-Return-Format') == 'html'
+        assert captured_calls, "Jina was never called"
+        assert captured_calls[0] == 'markdown', f"Expected markdown first, got: {captured_calls}"
 
     def test_jina_is_tried_before_requests(self):
         """Jina must be the first attempt in the cascade."""
@@ -300,11 +310,19 @@ class TestEvaluateServiceCascade:
         assert result['fetch_failed'] is False
 
     def test_uses_jina_when_requests_fails(self):
-        html = '<html><body><a href="/pricing">Pricing $9/mo</a><p>Sign up today for cloud infrastructure services with transparent pricing and a public SLA.</p></body></html>'
+        markdown = (
+            'Title: Example Cloud\n\n'
+            'URL Source: https://example.com\n\n'
+            'Markdown Content:\n'
+            'Welcome to Example Cloud. We provide infrastructure services.\n'
+            '[Pricing](https://example.com/pricing) starts at $9/mo.\n'
+            '[Sign up](https://example.com/signup) today for transparent pricing.\n'
+            'Our platform offers reliable cloud infrastructure with a public SLA and 99.9% uptime.\n'
+        )
 
         def side_effect(url, **kwargs):
             if 'r.jina.ai' in url:
-                return _make_response(html)
+                return _make_response(markdown)
             raise requests.exceptions.ConnectionError('blocked')
 
         with patch('requests.get', side_effect=side_effect):


### PR DESCRIPTION
## Summary

- **Recategorize 140 misplaced entries** across the README — after the category restructure (20ee61e), entries stayed in parent categories instead of being redistributed into new sub-categories (GPU & AI Compute, Analytics, Observability, ETL, PaaS, AI Coding were all empty)
- **Fix submission validator false rejections** on SPA/JS-heavy sites (tiiny.host, driver.dev, nomadicai.com) — Jina Reader's HTML mode returned unrendered SPA shells, causing pricing and signup detection to fail
- Remove duplicate Storadera entry (typo URL), restore missing section descriptions, alphabetical sort within all categories

### Category fixes

| Move | Count |
|------|-------|
| Databases & Storage → Observability & Monitoring | 22 |
| Databases & Storage → Analytics & Data Warehousing | 16 |
| Infrastructure Clouds → GPU & AI Compute Clouds | 34 |
| Developer Tooling & CI/CD → PaaS & Application Hosting | 13 |
| AI Assistants/Dev Tooling → AI Coding & App Generation | 12 |
| Network & Connectivity → Security/Auth categories | 10 |
| Databases & Storage → Data Integration & ETL | 6 |
| AI Assistants → AI Inference & Model APIs | 5 |
| Other single-entry corrections | 22 |

### Validator fixes

- Try Jina markdown mode first (renders JS), convert markdown links to BeautifulSoup
- Detect empty SPA shells and continue the fetch cascade instead of accepting them
- Probe common URL paths (`/pricing`, `/signup`, `/login`) when link detection fails
- Check homepage text for pricing/signup indicators as fallback
- Expand detection patterns (free plan, free trial, per month, etc.)

## Test plan

- [x] All 68 tests pass (`pytest tests/ -v`)
- [x] Verified fix against all 3 reported false rejections:
  - tiiny.host: 1/3 → 3/3
  - driver.dev: 1/3 → 2/3
  - nomadicai.com: 1/3 → 3/3
- [x] `clouds.json` regenerated from updated README (411 services, 23 categories)
- [ ] Manually verify a few category placements look correct on https://www.alt-cloud.org
- [ ] Re-run evaluation on issues #138, #139, #140 after merge

Fixes #138, #139, #140