### PR TITLE
fix: trigger evaluation when submission label is added after issue open

### DIFF
--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -2,12 +2,15 @@ name: Evaluate Submission
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
   evaluate:
-    # Only run on issues with 'submission' label
-    if: contains(github.event.issue.labels.*.name, 'submission')
+    # Run when a submission issue is opened with the label already applied,
+    # OR when the 'submission' label is added to an existing issue.
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'submission') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'submission'))
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/split-submission.yml
+++ b/.github/workflows/split-submission.yml
@@ -2,12 +2,16 @@ name: Split Multi-URL Submission
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
   split:
-    # Only run on submission issues that contain more than one real URL
-    if: contains(github.event.issue.labels.*.name, 'submission')
+    # Only run on submission issues that contain more than one real URL.
+    # Triggers when opened with the label already applied, or when the label
+    # is added later (e.g. by an admin to a manually-created issue).
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'submission') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'submission'))
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Previously, issues created manually on GitHub without the submission label were silently skipped — the opened event fired before the label existed. Now both evaluate-submission and split-submission also trigger on the labeled event, so an admin can apply the submission label at any time to kick off evaluation.