### PR TITLE
feat: dateAdded in clouds.json, JSON-LD, llms.txt, llms-full.txt

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,17 +26,21 @@ jobs:
       - name: Generate clouds.json from README
         run: |
           python scripts/parse_readme_to_json.py README.md docs/clouds.json
-          
-      - name: Commit updated clouds.json
+
+      - name: Generate llms.txt and llms-full.txt from clouds.json
+        run: |
+          python scripts/generate_llms.py docs/clouds.json docs/
+
+      - name: Commit updated files
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/clouds.json
-          
+          git add docs/clouds.json docs/llms.txt docs/llms-full.txt
+
           # Only commit if there are changes
           if ! git diff --staged --quiet; then
             git commit -m "Auto-update clouds.json from README [skip ci]"
             git push
           else
-            echo "No changes to clouds.json"
+            echo "No changes to clouds.json, llms.txt, or llms-full.txt"
           fi

--- a/docs/clouds.json
+++ b/docs/clouds.json
@@ -6,7 +6,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-20"
   },
   {
     "name": "Atlantic.net",
@@ -15,7 +16,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Axiom",
@@ -24,7 +26,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-09"
   },
   {
     "name": "Beam",
@@ -33,7 +36,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Browser-Use",
@@ -42,7 +46,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-03"
   },
   {
     "name": "Civo",
@@ -51,7 +56,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cycle.io",
@@ -60,7 +66,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "DataPacket",
@@ -69,7 +76,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Digital Ocean",
@@ -78,7 +86,18 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Driver",
+    "url": "https://driver.dev/",
+    "description": "Provides browser automation infrastructure running Chrome instances on real consumer hardware with residential IPs and authentic fingerprints for AI agents and web scraping.",
+    "score": 3,
+    "categories": [
+      "Infrastructure Clouds"
+    ],
+    "dateAdded": "2026-04-13"
   },
   {
     "name": "E2E Cloud",
@@ -87,7 +106,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Empromptu",
@@ -96,7 +116,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-20"
   },
   {
     "name": "exe.dev",
@@ -105,7 +126,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Firmus",
@@ -114,7 +136,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-18"
   },
   {
     "name": "Freestyle",
@@ -123,7 +146,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-04-06"
   },
   {
     "name": "Gcore",
@@ -132,7 +156,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hetzner",
@@ -141,7 +166,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hivelocity",
@@ -150,7 +176,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "IONOS Cloud",
@@ -159,7 +186,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Kernel",
@@ -168,7 +196,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-03"
   },
   {
     "name": "Latitude.sh",
@@ -177,7 +206,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "LeaseWeb",
@@ -186,7 +216,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Linode",
@@ -195,7 +226,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Lyceum",
@@ -204,7 +236,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Namespace",
@@ -213,7 +246,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-18"
   },
   {
     "name": "NetActuate",
@@ -222,7 +256,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Openmetal.io",
@@ -231,7 +266,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "OVH Cloud",
@@ -240,7 +276,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "QBO",
@@ -249,7 +286,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-10"
   },
   {
     "name": "Rackdog",
@@ -258,7 +296,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-18"
   },
   {
     "name": "Rackspace",
@@ -267,7 +306,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Salad",
@@ -276,7 +316,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Scaleway",
@@ -285,7 +326,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Seeweb",
@@ -294,7 +336,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Sent",
@@ -303,7 +346,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-03"
   },
   {
     "name": "Servers.com",
@@ -312,7 +356,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Spheron Network",
@@ -321,7 +366,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Sprites",
@@ -330,7 +376,8 @@
     "score": 2,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-02"
   },
   {
     "name": "Sustainable Metal Cloud",
@@ -339,7 +386,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Vultr",
@@ -348,7 +396,8 @@
     "score": 3,
     "categories": [
       "Infrastructure Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Aethir",
@@ -357,7 +406,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Anyscale",
@@ -366,7 +416,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Banana.dev",
@@ -375,7 +426,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Baseten",
@@ -384,7 +436,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cerebrium",
@@ -393,7 +446,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "CoreWeave",
@@ -402,7 +456,8 @@
     "score": 2,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Crusoe Energy",
@@ -411,7 +466,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cudo Compute",
@@ -420,7 +476,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Datacrunch.io",
@@ -429,7 +486,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Fal.ai",
@@ -438,7 +496,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "FluidStack",
@@ -447,7 +506,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "FriendliAI",
@@ -456,7 +516,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Genesis Cloud",
@@ -465,7 +526,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "GMI Cloud",
@@ -474,7 +536,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "GPU CLI",
@@ -483,7 +546,8 @@
     "score": 2,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-09"
   },
   {
     "name": "HydraHost",
@@ -492,7 +556,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hyperbolic",
@@ -501,7 +566,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hyperstack",
@@ -510,7 +576,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Lambda Labs",
@@ -519,7 +586,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "LeaderGPU",
@@ -528,7 +596,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Lightning.ai",
@@ -537,7 +606,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Modal",
@@ -546,7 +616,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Nebius",
@@ -555,7 +626,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "NeevCloud",
@@ -564,7 +636,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "NextGen Cloud",
@@ -573,7 +646,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Paperspace",
@@ -582,7 +656,8 @@
     "score": 2,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Parasail",
@@ -591,7 +666,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Runpod",
@@ -600,7 +676,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Shadeform",
@@ -609,7 +686,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "TensorDock",
@@ -618,7 +696,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "TensorWave",
@@ -627,7 +706,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Thunder Compute",
@@ -636,7 +716,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-30"
   },
   {
     "name": "Turboscale",
@@ -645,7 +726,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Vast.ai",
@@ -654,7 +736,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Voltage Park",
@@ -663,7 +746,8 @@
     "score": 3,
     "categories": [
       "GPU & AI Compute Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "CrowdStrike",
@@ -672,7 +756,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Fortinet",
@@ -681,7 +766,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "FPT Vietnam",
@@ -690,7 +776,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "GMO GPU Cloud",
@@ -699,7 +786,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Jottacloud",
@@ -708,7 +796,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "metalstack.cloud",
@@ -717,7 +806,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Netskope",
@@ -726,7 +816,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Ola Krutrim",
@@ -735,7 +826,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Operant",
@@ -744,7 +836,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Reliance",
@@ -753,7 +846,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Sakura Internet",
@@ -762,7 +856,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "T-Systems",
@@ -771,7 +866,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Wiz",
@@ -780,7 +876,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Yotta",
@@ -789,7 +886,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Zscaler",
@@ -798,7 +896,8 @@
     "score": 3,
     "categories": [
       "Security, Compliance & Sovereignty Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cosmonic",
@@ -807,7 +906,8 @@
     "score": 3,
     "categories": [
       "Unikernels & WebAssembly"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "KraftCloud",
@@ -816,7 +916,8 @@
     "score": 3,
     "categories": [
       "Unikernels & WebAssembly"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "NanoVMs",
@@ -825,7 +926,8 @@
     "score": 3,
     "categories": [
       "Unikernels & WebAssembly"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Wasmer",
@@ -834,7 +936,8 @@
     "score": 3,
     "categories": [
       "Unikernels & WebAssembly"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Aiven",
@@ -843,7 +946,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Algolia",
@@ -852,7 +956,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "CedarDB",
@@ -861,7 +966,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cockroach Labs",
@@ -870,7 +976,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Convex",
@@ -879,7 +986,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Couchbase",
@@ -888,7 +996,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Diffbot",
@@ -897,7 +1006,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Ditto",
@@ -906,7 +1016,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Gel",
@@ -915,7 +1026,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Hasura",
@@ -924,7 +1036,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hydrolix",
@@ -933,7 +1046,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "InfluxData",
@@ -942,7 +1056,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Materialize",
@@ -951,7 +1066,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Meilisearch",
@@ -960,7 +1076,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Momento",
@@ -969,7 +1086,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "MongoDB",
@@ -978,7 +1096,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Neo4j",
@@ -987,7 +1106,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Neon",
@@ -996,7 +1116,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Planetscale",
@@ -1005,7 +1126,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Prisma",
@@ -1014,7 +1136,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "QuestDB",
@@ -1023,7 +1146,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "ReadySet",
@@ -1032,7 +1156,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Redis",
@@ -1041,7 +1166,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "SingleStore",
@@ -1050,7 +1176,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Steampipe",
@@ -1059,7 +1186,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Storadera",
@@ -1068,7 +1196,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Supabase",
@@ -1077,7 +1206,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "SurrealDB",
@@ -1086,7 +1216,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "TigerData",
@@ -1095,7 +1226,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tigris",
@@ -1104,7 +1236,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Turso",
@@ -1113,7 +1246,8 @@
     "score": 2,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Typesense",
@@ -1122,7 +1256,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Upstash",
@@ -1131,7 +1266,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Wasabi",
@@ -1140,7 +1276,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Xata",
@@ -1149,7 +1286,8 @@
     "score": 3,
     "categories": [
       "Databases & Storage"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Amplitude",
@@ -1158,7 +1296,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "ClickHouse",
@@ -1167,7 +1306,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Databricks",
@@ -1176,7 +1316,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Domo",
@@ -1185,7 +1326,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "DuckDB",
@@ -1194,7 +1336,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Fathom",
@@ -1203,7 +1346,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Firebolt",
@@ -1212,7 +1356,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "FullStory",
@@ -1221,7 +1366,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Heap",
@@ -1230,7 +1376,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Mixpanel",
@@ -1239,7 +1386,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "MotherDuck",
@@ -1248,7 +1396,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Plausible",
@@ -1257,7 +1406,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "PostHog",
@@ -1266,7 +1416,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Snowflake",
@@ -1275,7 +1426,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Teradata",
@@ -1284,7 +1436,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Tinybird",
@@ -1293,7 +1446,8 @@
     "score": 3,
     "categories": [
       "Analytics & Data Warehousing"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "BetterStack",
@@ -1302,7 +1456,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Checkly",
@@ -1311,7 +1466,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Chronosphere",
@@ -1320,7 +1476,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Comet",
@@ -1329,7 +1486,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Coralogix",
@@ -1338,7 +1496,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Datadog",
@@ -1347,7 +1506,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Dynatrace",
@@ -1356,7 +1516,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Elastic",
@@ -1365,7 +1526,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Gigapipe",
@@ -1374,7 +1536,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-03-03"
   },
   {
     "name": "Grafana",
@@ -1383,7 +1546,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "groundcover",
@@ -1392,7 +1556,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Helicone",
@@ -1401,7 +1566,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Highlight",
@@ -1410,7 +1576,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Honeycomb",
@@ -1419,7 +1586,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Kentik",
@@ -1428,7 +1596,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Laminar",
@@ -1437,7 +1606,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "LogRocket",
@@ -1446,7 +1616,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Logz.io",
@@ -1455,7 +1626,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Mezmo",
@@ -1464,7 +1636,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "New Relic",
@@ -1473,7 +1646,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "OpenStatus",
@@ -1482,7 +1656,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Sentry",
@@ -1491,7 +1666,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Splunk",
@@ -1500,7 +1676,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Sumo Logic",
@@ -1509,7 +1686,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Weights & Biases",
@@ -1518,7 +1696,8 @@
     "score": 3,
     "categories": [
       "Observability & Monitoring"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Airbyte",
@@ -1527,7 +1706,8 @@
     "score": 3,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Arroyo",
@@ -1536,7 +1716,8 @@
     "score": 2,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2026-02-25"
   },
   {
     "name": "dbt Labs",
@@ -1545,7 +1726,18 @@
     "score": 3,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Firecrawl",
+    "url": "https://www.firecrawl.dev/",
+    "description": "Provides web scraping and crawling API that converts websites into clean markdown or structured data, specifically designed for AI applications and LLM training.",
+    "score": 3,
+    "categories": [
+      "Data Integration & ETL"
+    ],
+    "dateAdded": "2026-04-14"
   },
   {
     "name": "Fivetran",
@@ -1554,7 +1746,8 @@
     "score": 3,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Redpanda",
@@ -1563,7 +1756,8 @@
     "score": 3,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Rivery",
@@ -1572,7 +1766,8 @@
     "score": 3,
     "categories": [
       "Data Integration & ETL"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Alloy Automation",
@@ -1581,7 +1776,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Dagster",
@@ -1590,7 +1786,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Fastn",
@@ -1599,7 +1796,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Inngest",
@@ -1608,7 +1806,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Kestra",
@@ -1617,7 +1816,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Mabl",
@@ -1626,7 +1826,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Miter",
@@ -1635,7 +1836,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "n8n",
@@ -1644,7 +1846,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "PagerDuty",
@@ -1653,7 +1856,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Prefect",
@@ -1662,7 +1866,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Ryvn",
@@ -1671,7 +1876,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "ServiceNow",
@@ -1680,7 +1886,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Temporal",
@@ -1689,7 +1896,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tines",
@@ -1698,7 +1906,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Windmill",
@@ -1707,7 +1916,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Zapier",
@@ -1716,7 +1926,8 @@
     "score": 3,
     "categories": [
       "Workflow & Operations Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Akamai",
@@ -1725,7 +1936,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Approximated",
@@ -1734,7 +1946,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Aviatrix",
@@ -1743,7 +1956,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "c/Side",
@@ -1752,7 +1966,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cloudbrink",
@@ -1761,7 +1976,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cloudflare",
@@ -1770,7 +1986,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "CtrlDNS",
@@ -1779,7 +1996,8 @@
     "score": 2,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-02-13"
   },
   {
     "name": "Fastly",
@@ -1788,7 +2006,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "IPinfo",
@@ -1797,7 +2016,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-23"
   },
   {
     "name": "Kong",
@@ -1806,7 +2026,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "LocalXpose",
@@ -1815,7 +2036,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Macrometa",
@@ -1824,7 +2046,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Megaport",
@@ -1833,7 +2056,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "NetBox Cloud",
@@ -1842,7 +2066,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Netmaker",
@@ -1851,7 +2076,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Pangolin",
@@ -1860,7 +2086,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Subspace",
@@ -1869,7 +2096,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tailscale",
@@ -1878,7 +2106,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Twingate",
@@ -1887,7 +2116,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Versa Networks",
@@ -1896,7 +2126,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "ZeroTier",
@@ -1905,7 +2136,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-31"
   },
   {
     "name": "zrok",
@@ -1914,7 +2146,8 @@
     "score": 3,
     "categories": [
       "Network & Connectivity Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Anchor",
@@ -1923,7 +2156,18 @@
     "score": 2,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2026-03-20"
+  },
+  {
+    "name": "Cloudglue",
+    "url": "https://cloudglue.dev/",
+    "description": "Provides a video context engine API that structures, searches, and enables AI reasoning over video content for developers building chatbots, RAG systems, and video analysis applications.",
+    "score": 2,
+    "categories": [
+      "AI Inference & Model APIs"
+    ],
+    "dateAdded": "2026-04-16"
   },
   {
     "name": "Fireworks.ai",
@@ -1932,7 +2176,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Groq",
@@ -1941,7 +2186,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "LeptonAI",
@@ -1950,7 +2196,18 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Nomadic",
+    "url": "https://www.nomadicai.com/",
+    "description": "Provides AI-powered video analysis platform that automatically identifies rare events and edge cases in robotic, autonomous vehicle, and construction footage for training physical AI systems.",
+    "score": 2,
+    "categories": [
+      "AI Inference & Model APIs"
+    ],
+    "dateAdded": "2026-04-13"
   },
   {
     "name": "Parallel",
@@ -1959,7 +2216,8 @@
     "score": 2,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2026-03-31"
   },
   {
     "name": "Portkey",
@@ -1968,7 +2226,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Replicate",
@@ -1977,7 +2236,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Roboflow",
@@ -1986,7 +2246,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Together.ai",
@@ -1995,7 +2256,8 @@
     "score": 3,
     "categories": [
       "AI Inference & Model APIs"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "AssemblyAI",
@@ -2004,7 +2266,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Bluedot",
@@ -2013,7 +2276,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Character.ai",
@@ -2022,7 +2286,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "ChatGPT by OpenAI",
@@ -2031,7 +2296,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Chatsonic",
@@ -2040,7 +2306,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Claude",
@@ -2049,7 +2316,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cohere",
@@ -2058,7 +2326,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "DeepAI",
@@ -2067,7 +2336,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Deepseek",
@@ -2076,7 +2346,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "ElevenLabs",
@@ -2085,7 +2356,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Elicit",
@@ -2094,7 +2366,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Kimi AI",
@@ -2103,7 +2376,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-02-09"
   },
   {
     "name": "Layer 9",
@@ -2112,7 +2386,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "NeuBird",
@@ -2121,7 +2396,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Parahelp",
@@ -2130,7 +2406,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Perplexity",
@@ -2139,7 +2416,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Playground",
@@ -2148,7 +2426,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Poe",
@@ -2157,7 +2436,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Resolve.ai",
@@ -2166,7 +2446,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "SharonAI",
@@ -2175,7 +2456,8 @@
     "score": 2,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-02-14"
   },
   {
     "name": "Supertrace AI",
@@ -2184,7 +2466,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Surfer AI",
@@ -2193,7 +2476,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Tavus",
@@ -2202,7 +2486,8 @@
     "score": 3,
     "categories": [
       "AI Assistants & Copilots"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Base44",
@@ -2211,7 +2496,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Bolt",
@@ -2220,7 +2506,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Codev",
@@ -2229,7 +2516,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "CopilotKit",
@@ -2238,7 +2526,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cursor",
@@ -2247,7 +2536,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Git AI",
@@ -2256,7 +2546,8 @@
     "score": 2,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-03-31"
   },
   {
     "name": "GitHub Copilot",
@@ -2265,7 +2556,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Marblism",
@@ -2274,7 +2566,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Mesa",
@@ -2283,7 +2576,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "OB-1",
@@ -2292,7 +2586,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-03-31"
   },
   {
     "name": "Softgen",
@@ -2301,7 +2596,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Tabnine",
@@ -2310,7 +2606,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "v0",
@@ -2319,7 +2616,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Windsurf",
@@ -2328,7 +2626,8 @@
     "score": 3,
     "categories": [
       "AI Coding & App Generation"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Deno Deploy",
@@ -2337,7 +2636,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Flightcontrol",
@@ -2346,7 +2646,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Fly",
@@ -2355,7 +2656,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Gadget",
@@ -2364,7 +2666,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Heroku",
@@ -2373,7 +2676,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Koyeb",
@@ -2382,7 +2686,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Netlify",
@@ -2391,7 +2696,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Northflank",
@@ -2400,7 +2706,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Pantheon",
@@ -2409,7 +2716,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Platform.sh",
@@ -2418,7 +2726,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Porter",
@@ -2427,7 +2736,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Puter",
@@ -2436,7 +2746,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Railway",
@@ -2445,7 +2756,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Render",
@@ -2454,7 +2766,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Shuttle",
@@ -2463,7 +2776,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Skyhook",
@@ -2472,7 +2786,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2026-04-12"
   },
   {
     "name": "Upsun",
@@ -2481,7 +2796,8 @@
     "score": 3,
     "categories": [
       "PaaS & Application Hosting"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Browserbase",
@@ -2490,7 +2806,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "browserless",
@@ -2499,7 +2816,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Bubble",
@@ -2508,7 +2826,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cloudsmith",
@@ -2517,7 +2836,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Coder",
@@ -2526,7 +2846,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Cypress",
@@ -2535,7 +2856,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Depot",
@@ -2544,7 +2866,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "DevZero",
@@ -2553,7 +2876,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Dosu",
@@ -2562,7 +2886,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "E2B",
@@ -2571,7 +2896,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Fabrica",
@@ -2580,7 +2906,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Firefly",
@@ -2589,7 +2916,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Flagsmith",
@@ -2598,7 +2926,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Gammacode",
@@ -2607,7 +2936,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Gitpod",
@@ -2616,7 +2946,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "HashiCorp Cloud Platform",
@@ -2625,7 +2956,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Helix",
@@ -2634,7 +2966,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-03-02"
   },
   {
     "name": "JetBrains",
@@ -2643,7 +2976,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Lightrun",
@@ -2652,7 +2986,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Linear",
@@ -2661,7 +2996,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Mintlify",
@@ -2670,7 +3006,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Notion",
@@ -2679,7 +3016,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Outerbase",
@@ -2688,7 +3026,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Prismic",
@@ -2697,7 +3036,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Release",
@@ -2706,7 +3046,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Replit",
@@ -2715,7 +3056,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Retool",
@@ -2724,7 +3066,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Runloop",
@@ -2733,7 +3076,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-02-23"
   },
   {
     "name": "StackBlitz",
@@ -2742,7 +3086,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tensorlake",
@@ -2751,7 +3096,8 @@
     "score": 2,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-03-06"
   },
   {
     "name": "Tiptap",
@@ -2760,7 +3106,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Ubicloud",
@@ -2769,7 +3116,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Unleash",
@@ -2778,7 +3126,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Warp",
@@ -2787,7 +3136,8 @@
     "score": 3,
     "categories": [
       "Developer Tooling & CI/CD"
-    ]
+    ],
+    "dateAdded": "2026-02-13"
   },
   {
     "name": "Akeyless",
@@ -2796,7 +3146,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Aserto",
@@ -2805,7 +3156,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Auth0",
@@ -2814,7 +3166,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Authzed",
@@ -2823,7 +3176,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Bolster",
@@ -2832,7 +3186,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Boundary",
@@ -2841,7 +3196,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Cerbos",
@@ -2850,7 +3206,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "CipherStash",
@@ -2859,7 +3216,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Clerk",
@@ -2868,7 +3226,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Descope",
@@ -2877,7 +3236,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Doppler",
@@ -2886,7 +3246,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Duo",
@@ -2895,7 +3256,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Frontegg",
@@ -2904,7 +3266,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "FusionAuth",
@@ -2913,7 +3276,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Infisical",
@@ -2922,7 +3286,8 @@
     "score": 2,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "JumpCloud",
@@ -2931,7 +3296,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Keet",
@@ -2940,7 +3306,18 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Keycard",
+    "url": "https://www.keycard.ai/",
+    "description": "Provides identity-based access control and governance for autonomous AI agents, offering policy enforcement, credential management, and audit trails for agent interactions with APIs and data.",
+    "score": 2,
+    "categories": [
+      "Authorization, Identity & Fraud"
+    ],
+    "dateAdded": "2026-04-16"
   },
   {
     "name": "Keycloak",
@@ -2949,7 +3326,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Ory",
@@ -2958,7 +3336,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Oso",
@@ -2967,7 +3346,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Pangea",
@@ -2976,7 +3356,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Permit",
@@ -2985,7 +3366,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Pomerium",
@@ -2994,7 +3376,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "PropelAuth",
@@ -3003,7 +3386,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Sift Science",
@@ -3012,7 +3396,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "StrongDM",
@@ -3021,7 +3406,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Stytch",
@@ -3030,7 +3416,8 @@
     "score": 2,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Teleport",
@@ -3039,7 +3426,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Warrant",
@@ -3048,7 +3436,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "WorkOS",
@@ -3057,7 +3446,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Xpander.ai",
@@ -3066,7 +3456,8 @@
     "score": 3,
     "categories": [
       "Authorization, Identity & Fraud"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Amberflo",
@@ -3075,7 +3466,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Autumn",
@@ -3084,7 +3476,8 @@
     "score": 2,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-03-31"
   },
   {
     "name": "Bill",
@@ -3093,7 +3486,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Dodo Payments",
@@ -3102,7 +3496,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Lago",
@@ -3111,7 +3506,8 @@
     "score": 2,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Lemon Squeezy",
@@ -3120,7 +3516,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "m3ter",
@@ -3129,7 +3526,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Maxio",
@@ -3138,7 +3536,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Mercury",
@@ -3147,7 +3546,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-26"
   },
   {
     "name": "Metronome",
@@ -3156,7 +3556,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "N26",
@@ -3165,7 +3566,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "OpenMeter",
@@ -3174,7 +3576,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Orb",
@@ -3183,7 +3586,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Recurly",
@@ -3192,7 +3596,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Salesforce Revenue Cloud",
@@ -3201,7 +3606,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Schematic",
@@ -3210,7 +3616,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Stigg",
@@ -3219,7 +3626,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Stripe",
@@ -3228,7 +3636,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Togai",
@@ -3237,7 +3646,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "UniBee",
@@ -3246,7 +3656,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Wise",
@@ -3255,7 +3666,8 @@
     "score": 3,
     "categories": [
       "Monetization & Billing Clouds"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Attio",
@@ -3264,7 +3676,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Beehiiv",
@@ -3273,7 +3686,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Clarify",
@@ -3282,7 +3696,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Customer.io",
@@ -3291,7 +3706,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Formbricks",
@@ -3300,7 +3716,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Front",
@@ -3309,7 +3726,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Helpscout",
@@ -3318,7 +3736,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Hubspot",
@@ -3327,7 +3746,18 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Jasper",
+    "url": "https://www.jasper.ai/",
+    "description": "Provides AI-powered marketing automation platform with intelligent agents and content pipelines for creating, scaling, and managing brand-consistent marketing content across all channels.",
+    "score": 3,
+    "categories": [
+      "Customer, Marketing & eCommerce"
+    ],
+    "dateAdded": "2026-04-24"
   },
   {
     "name": "Klaviyo",
@@ -3336,7 +3766,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Mirakl",
@@ -3345,7 +3776,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Plain",
@@ -3354,7 +3786,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2026-04-12"
   },
   {
     "name": "Shopify",
@@ -3363,7 +3796,18 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
+  },
+  {
+    "name": "Stonly",
+    "url": "https://stonly.com/",
+    "description": "Provides a knowledge management platform for customer service with interactive guides, AI-powered chatbots, and process automation to help support agents and enable customer self-service.",
+    "score": 3,
+    "categories": [
+      "Customer, Marketing & eCommerce"
+    ],
+    "dateAdded": "2026-04-16"
   },
   {
     "name": "Zendesk",
@@ -3372,7 +3816,8 @@
     "score": 3,
     "categories": [
       "Customer, Marketing & eCommerce"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "1NCE",
@@ -3381,7 +3826,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "api.video",
@@ -3390,7 +3836,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Gradium",
@@ -3399,7 +3846,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2026-02-13"
   },
   {
     "name": "Hologram",
@@ -3408,7 +3856,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Knock",
@@ -3417,7 +3866,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Mux",
@@ -3426,7 +3876,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Onomondo",
@@ -3435,7 +3886,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Particle",
@@ -3444,7 +3896,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Resend",
@@ -3453,7 +3906,8 @@
     "score": 2,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Samsara",
@@ -3462,7 +3916,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Sendbird",
@@ -3471,7 +3926,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "SLNG",
@@ -3480,7 +3936,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Soracom",
@@ -3489,7 +3946,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Twilio",
@@ -3498,7 +3956,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Wistia",
@@ -3507,7 +3966,8 @@
     "score": 3,
     "categories": [
       "Communications, IoT & Media"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Akash Network",
@@ -3516,7 +3976,8 @@
     "score": 3,
     "categories": [
       "Decentralized & Web3 Compute"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Gitea Cloud",
@@ -3525,7 +3986,8 @@
     "score": 3,
     "categories": [
       "Source Code Control"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "GitHub",
@@ -3534,7 +3996,8 @@
     "score": 3,
     "categories": [
       "Source Code Control"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "GitLab",
@@ -3543,7 +4006,8 @@
     "score": 3,
     "categories": [
       "Source Code Control"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Edgeless Systems",
@@ -3552,7 +4016,8 @@
     "score": 3,
     "categories": [
       "Cloud Adjacent & Infrastructure Tooling"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "ngrok",
@@ -3561,7 +4026,8 @@
     "score": 3,
     "categories": [
       "Cloud Adjacent & Infrastructure Tooling"
-    ]
+    ],
+    "dateAdded": "2025-05-05"
   },
   {
     "name": "Solo.io",
@@ -3570,7 +4036,8 @@
     "score": 3,
     "categories": [
       "Cloud Adjacent & Infrastructure Tooling"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tetrate",
@@ -3579,7 +4046,8 @@
     "score": 3,
     "categories": [
       "Cloud Adjacent & Infrastructure Tooling"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "API7",
@@ -3588,7 +4056,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Apigee",
@@ -3597,7 +4066,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Chroma",
@@ -3606,7 +4076,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Eppo",
@@ -3615,7 +4086,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "FeatBit",
@@ -3624,7 +4096,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "KrakenD",
@@ -3633,7 +4106,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "LaunchDarkly",
@@ -3642,7 +4116,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "OpenObserve",
@@ -3651,7 +4126,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Oxide Computer",
@@ -3660,7 +4136,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Split",
@@ -3669,7 +4146,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Statsig",
@@ -3678,7 +4156,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Tggl",
@@ -3687,7 +4166,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Turbopuffer",
@@ -3696,7 +4176,8 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   },
   {
     "name": "Uptrace",
@@ -3705,6 +4186,7 @@
     "score": 3,
     "categories": [
       "Emerging & Unverified Providers"
-    ]
+    ],
+    "dateAdded": "2026-01-29"
   }
 ]

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,20 +8,109 @@
 
   <!-- Open Graph / Facebook / LinkedIn -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://datum-cloud.github.io/awesome-alt-clouds/">
+  <meta property="og:url" content="https://www.alt-cloud.org/">
   <meta property="og:title" content="Awesome Alt Clouds - When you need something specialized">
   <meta property="og:description" content="A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.">
-  <meta property="og:image" content="https://datum-cloud.github.io/awesome-alt-clouds/og-image.png">
+  <meta property="og:image" content="https://www.alt-cloud.org/og-image.png">
   <meta property="og:image:width" content="1206">
   <meta property="og:image:height" content="634">
   <meta property="og:image:type" content="image/png">
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://datum-cloud.github.io/awesome-alt-clouds/">
+  <meta name="twitter:url" content="https://www.alt-cloud.org/">
   <meta name="twitter:title" content="Awesome Alt Clouds - When you need something specialized">
   <meta name="twitter:description" content="A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.">
-  <meta name="twitter:image" content="https://datum-cloud.github.io/awesome-alt-clouds/og-image.png">
+  <meta name="twitter:image" content="https://www.alt-cloud.org/og-image.png">
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://www.alt-cloud.org/">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://www.alt-cloud.org/#website",
+        "url": "https://www.alt-cloud.org/",
+        "name": "Awesome Alt Clouds",
+        "description": "Curated directory of 419+ alternative cloud providers evaluated against transparent pricing, self-service signup, and public SLA criteria.",
+        "inLanguage": "en",
+        "publisher": { "@id": "https://www.alt-cloud.org/#organization" }
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://www.alt-cloud.org/#organization",
+        "name": "Datum Cloud",
+        "url": "https://www.alt-cloud.org",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://www.alt-cloud.org/og-image.png",
+          "width": 1206,
+          "height": 634
+        },
+        "sameAs": [
+          "https://github.com/datum-cloud",
+          "https://github.com/datum-cloud/awesome-alt-clouds"
+        ],
+        "knowsAbout": [
+          "cloud computing",
+          "alternative cloud providers",
+          "infrastructure as a service",
+          "GPU cloud computing",
+          "developer tools",
+          "database services",
+          "AI inference APIs",
+          "platform as a service"
+        ]
+      },
+      {
+        "@type": "Dataset",
+        "@id": "https://www.alt-cloud.org/#dataset",
+        "name": "Awesome Alt Clouds Directory",
+        "description": "A curated, community-maintained dataset of 419+ alternative cloud service providers evaluated against 3 criteria: transparent public pricing, usage-based self-service signup, and public SLA or status page. Covers 23 categories including infrastructure, GPU compute, databases, AI inference, developer tooling, and more.",
+        "url": "https://www.alt-cloud.org/",
+        "keywords": [
+          "cloud computing", "alternative cloud", "infrastructure as a service",
+          "GPU cloud", "databases", "developer tools", "PaaS", "AI inference",
+          "observability", "authorization", "network connectivity"
+        ],
+        "creator": { "@id": "https://www.alt-cloud.org/#organization" },
+        "license": "https://creativecommons.org/licenses/by/4.0/",
+        "isAccessibleForFree": true,
+        "distribution": [
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "application/json",
+            "contentUrl": "https://www.alt-cloud.org/clouds.json",
+            "name": "clouds.json — machine-readable cloud services directory"
+          },
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "text/markdown",
+            "contentUrl": "https://raw.githubusercontent.com/datum-cloud/awesome-alt-clouds/main/README.md",
+            "name": "README.md — human-readable awesome list"
+          }
+        ]
+      },
+      {
+        "@type": "CollectionPage",
+        "@id": "https://www.alt-cloud.org/#webpage",
+        "url": "https://www.alt-cloud.org/",
+        "name": "Awesome Alt Clouds | Alternative Cloud Providers for Developers",
+        "description": "Discover specialized cloud infrastructure providers built for developers who have specialized requirements and need alternatives to hyperscalers.",
+        "isPartOf": { "@id": "https://www.alt-cloud.org/#website" },
+        "about": { "@id": "https://www.alt-cloud.org/#dataset" },
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": [".hero-title", ".hero-subtitle"]
+        }
+      }
+    ]
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7,7 +7,7 @@
 - [Directory Homepage](https://www.alt-cloud.org/): Interactive searchable directory. Filter by category, search by name or description, sort alphabetically, by score, or by recently added date. All data loaded from /clouds.json.
 - [Submit a Service](https://www.alt-cloud.org/submit/): Web form that creates a GitHub issue, triggers automated AI evaluation (pricing page detection, signup detection, status page detection), and opens a PR on pass.
 - [GitHub Repository](https://github.com/datum-cloud/awesome-alt-clouds): Source of truth. Contains README.md (the awesome list), evaluation scripts in /scripts, and GitHub Actions workflows in .github/workflows.
-- [Machine-Readable Data](https://www.alt-cloud.org/clouds.json): JSON array of all entries with fields: name, url, description, score (2 or 3), categories (array), dateAdded (ISO date from git history).
+- [Machine-Readable Data](https://www.alt-cloud.org/clouds.json): JSON array of all 419+ entries with fields: name, url, description, score (2 or 3), categories (array), dateAdded (ISO date from git history).
 
 ## Evaluation Criteria
 
@@ -15,7 +15,7 @@ Services are scored against 3 criteria. A minimum score of 2/3 is required for i
 
 1. **Transparent Public Pricing** — a publicly accessible pricing page with actual prices or tiers visible without signing up or contacting sales.
 2. **Usage-Based Self-Service** — ability to sign up and start using the service without sales intervention; includes free trials, free tiers, or pay-as-you-go billing.
-3. **Production Indicators** — a public SLA commitment, status page, or uptime transparency indicator (e.g., statuspage.io, status subdomain).
+3. **Production Indicators** — a public SLA commitment, status page, or uptime transparency indicator (e.g. statuspage.io, status subdomain).
 
 Score legend: 🟢 = 3/3 criteria met | 🟡 = 2/3 criteria met
 
@@ -25,141 +25,139 @@ Score legend: 🟢 = 3/3 criteria met | 🟡 = 2/3 criteria met
 
 General-purpose cloud compute, bare metal, and VPS providers. The original "alt clouds" offering virtualized compute, dedicated servers, GPU instances, storage, and Kubernetes services outside the hyperscaler ecosystem.
 
-Key services: Digital Ocean, Vultr, Linode, Scaleway, Hetzner, Civo, Latitude.sh, Gcore, OVH Cloud, Rackspace, LeaseWeb, DataPacket, IONOS Cloud, Atlantic.net, Openmetal.io, Servers.com, NetActuate, Salad, Spheron Network, Sustainable Metal Cloud, QBO, Lyceum, E2E Cloud, Hivelocity, Cycle.io, Beam, Driver, exe.dev.
+Services: Arcade, Atlantic.net, Axiom, Beam, Browser-Use, Civo, Cycle.io, DataPacket, Digital Ocean, Driver, E2E Cloud, Empromptu, exe.dev, Firmus, Freestyle, and 25 more.
 
 ### GPU & AI Compute Clouds (35 services)
 
 Specialized GPU compute platforms for AI training, model fine-tuning, and high-performance workloads. Includes serverless GPU inference, GPU clusters, and distributed compute networks.
 
-Key services: Lambda Labs, Vast.ai, CoreWeave, Together AI, Banana.dev, Baseten, Anyscale, Aethir, Crusoe Energy, Fluidstack, Groq (hardware), Hyperbolic, Runpod, Lepton AI, TensorDock, Genesis Cloud, NVIDIA DGX Cloud, Modal, SF Compute, Nebius, Fal.ai.
+Services: Aethir, Anyscale, Banana.dev, Baseten, Cerebrium, CoreWeave, Crusoe Energy, Cudo Compute, Datacrunch.io, Fal.ai, FluidStack, FriendliAI, Genesis Cloud, GMI Cloud, GPU CLI, and 20 more.
 
 ### Databases & Storage (35 services)
 
 Managed database services, vector databases, distributed SQL, time series, object storage, and data warehousing — all self-service with public pricing.
 
-Key services: Neon, PlanetScale, CockroachDB, Turso, Xata, Upstash, Railway (Postgres), Supabase, Fly.io Postgres, SingleStore, Timescale, QuestDB, InfluxDB Cloud, Cloudflare R2, Backblaze B2, Storj, Filebase, MinIO Cloud, Tigris, Weaviate, Qdrant, Pinecone, Milvus, Chroma, Zilliz.
+Services: Aiven, Algolia, CedarDB, Cockroach Labs, Convex, Couchbase, Diffbot, Ditto, Gel, Hasura, Hydrolix, InfluxData, Materialize, Meilisearch, Momento, and 20 more.
 
 ### Developer Tooling & CI/CD (34 services)
 
 CI/CD platforms, code hosting, testing infrastructure, feature flags, error monitoring, and developer workflow automation.
 
-Key services: Railway, Render, Fly.io, Deno Deploy, Netlify, Vercel (alt), Cloudflare Workers/Pages, Zeet, Porter, Depot, BuildKite, Semaphore, Earthly, Trunk, Codecov, Sentry (alt), LaunchDarkly, Split.io, Statsig, Unleash, Flipt.
+Services: Browserbase, browserless, Bubble, Cloudsmith, Coder, Cypress, Depot, DevZero, Dosu, E2B, Fabrica, Firefly, Flagsmith, Gammacode, Gitpod, and 19 more.
 
 ### Authorization, Identity & Fraud (32 services)
 
 Authentication, authorization, identity management, secrets management, and fraud detection services with self-service onboarding.
 
-Key services: Auth0, Clerk, WorkOS, Stytch, Ory, Keycloak, FusionAuth, Descope, PropelAuth, Frontegg, JumpCloud, Okta (alt tiers), Duo, Pangea, Permit.io, Oso, Pomerium, Doppler, Infisical, HashiCorp Vault Cloud, Sift Science.
+Services: Akeyless, Aserto, Auth0, Authzed, Bolster, Boundary, Cerbos, CipherStash, Clerk, Descope, Doppler, Duo, Frontegg, FusionAuth, Infisical, and 17 more.
 
 ### Observability & Monitoring (25 services)
 
 Logging, metrics, tracing, APM, uptime monitoring, and error tracking platforms with pay-as-you-go or free tiers.
 
-Key services: Datadog (alt tiers), Grafana Cloud, New Relic, Honeycomb, Axiom, Highlight, OpenObserve, Signoz, Mezmo, Coralogix, Better Uptime, Checkly, Cronitor, Oh Dear, Pagerduty, Incident.io, Rootly, FireHydrant.
+Services: BetterStack, Checkly, Chronosphere, Comet, Coralogix, Datadog, Dynatrace, Elastic, Gigapipe, Grafana, groundcover, Helicone, Highlight, Honeycomb, Kentik, and 10 more.
 
 ### AI Assistants & Copilots (23 services)
 
 AI assistant platforms, copilot APIs, and conversational AI services for building customer-facing or developer-facing intelligent experiences.
 
-Key services: Anthropic Claude API, OpenAI (alt tiers), Cohere, AI21 Labs, Mistral AI, Perplexity API, You.com API, Kapa.ai, Mendable, Chatbase, Dust, Superagent, Relevance AI.
+Services: AssemblyAI, Bluedot, Character.ai, ChatGPT by OpenAI, Chatsonic, Claude, Cohere, DeepAI, Deepseek, ElevenLabs, Elicit, Kimi AI, Layer 9, NeuBird, Parahelp, and 8 more.
 
 ### Network & Connectivity Clouds (22 services)
 
 CDN, edge networking, DNS, DDoS protection, VPN, and private networking platforms.
 
-Key services: Cloudflare, Fastly, BunnyCDN, KeyCDN, Fly.io networking, Tailscale, ZeroTier, Netbird, Headscale, Ngrok, Cloudflare Tunnel, NS1, DNSimple, Route 53 (alt), Vercara.
+Services: Akamai, Approximated, Aviatrix, c/Side, Cloudbrink, Cloudflare, CtrlDNS, Fastly, IPinfo, Kong, LocalXpose, Macrometa, Megaport, NetBox Cloud, Netmaker, and 7 more.
 
 ### Monetization & Billing Clouds (21 services)
 
 Payment processing, subscription management, usage-based billing, metering, and revenue operations platforms.
 
-Key services: Stripe, Paddle, Lago, OpenMeter, Amberflo, Metronome, Orb, Stigg, Chargebee, Recurly, Maxio, Autumn, Useautumn, Paymongo, Lemon Squeezy.
-
-### Customer, Marketing & eCommerce (15 services)
-
-CRM, customer support, marketing automation, and e-commerce infrastructure platforms.
-
-Key services: Plain, Helpscout, Zendesk (alt tiers), Front, Hubspot (alt), Customer.io, Attio, Clarify, Klaviyo, Stonly, Jasper, Beehiiv, Shopify, Mirakl, Formbricks.
-
-### AI Coding & App Generation (14 services)
-
-AI-assisted code generation, app scaffolding, and developer productivity tools built on LLMs.
-
-Key services: GitHub Copilot (alt), Tabnine, Codeium, Cursor, Continue, Sourcegraph Cody, Replit AI, Bolt.new, Lovable, v0, Devin, SWE-agent.
+Services: Amberflo, Autumn, Bill, Dodo Payments, Lago, Lemon Squeezy, m3ter, Maxio, Mercury, Metronome, N26, OpenMeter, Orb, Recurly, Salesforce Revenue Cloud, and 6 more.
 
 ### PaaS & Application Hosting (17 services)
 
 Platform-as-a-service offerings for deploying web applications, APIs, and backend services with minimal infrastructure management.
 
-Key services: Heroku (alt tiers), Railway, Render, Fly.io, Porter, Zeet, Back4app, Koyeb, Adaptable.io, Northflank, Qoddi, Coolify, CapRover, Caprover.
-
-### Security, Compliance & Sovereignty Clouds (15 services)
-
-Security-focused cloud platforms with compliance certifications, data sovereignty options, air-gapped deployments, and sovereign cloud infrastructure.
-
-Key services: Hetzner (GDPR), OVH (French sovereignty), Exoscale, Cleura, STACKIT, Open Telekom Cloud, Bluvalt, T-Systems, Cipherstack, Idrivee2, Wasabi (compliance), Backblaze (HIPAA).
-
-### Communications, IoT & Media (15 services)
-
-Messaging APIs, email delivery, SMS, voice, video, push notifications, and IoT connectivity platforms.
-
-Key services: Twilio (alt tiers), Vonage/Nexmo, MessageBird, Sinch, Plivo, Telnyx, Postmark, Sendgrid (alt), Mailgun, Resend, Knock, Courier, Novu, Ably, Pusher.
-
-### Observability & Monitoring (25 services)
-
-See category details above.
+Services: Deno Deploy, Flightcontrol, Fly, Gadget, Heroku, Koyeb, Netlify, Northflank, Pantheon, Platform.sh, Porter, Puter, Railway, Render, Shuttle, and 2 more.
 
 ### Analytics & Data Warehousing (16 services)
 
 Cloud data warehouses, analytics databases, business intelligence platforms, and data lakehouse services.
 
-Key services: MotherDuck, Tinybird, ClickHouse Cloud, Firebolt, StarRocks Cloud, Hydra, Databend, DuckDB Cloud, Plandek, Redpanda Cloud.
+Services: Amplitude, ClickHouse, Databricks, Domo, DuckDB, Fathom, Firebolt, FullStory, Heap, Mixpanel, MotherDuck, Plausible, PostHog, Snowflake, Teradata, and 1 more.
 
 ### Workflow & Operations Clouds (16 services)
 
 Workflow orchestration, job queues, event streaming, and operations automation platforms.
 
-Key services: Inngest, Temporal Cloud, Trigger.dev, Zeplo, Winglang, Upstash Qstash, Quirrel, Windmill, n8n Cloud, Make (Integromat), Pipedream, Tray.io.
+Services: Alloy Automation, Dagster, Fastn, Inngest, Kestra, Mabl, Miter, n8n, PagerDuty, Prefect, Ryvn, ServiceNow, Temporal, Tines, Windmill, and 1 more.
 
-### Data Integration & ETL (7 services)
+### Security, Compliance & Sovereignty Clouds (15 services)
 
-Data pipeline, ETL, CDC, and integration platforms with self-service onboarding.
+Security-focused cloud platforms with compliance certifications, data sovereignty options, air-gapped deployments, and sovereign cloud infrastructure.
 
-Key services: Airbyte Cloud, Fivetran (alt tiers), Stitch, Segment (alt), Hightouch, Census, Polytomic, Firecrawl.
+Services: CrowdStrike, Fortinet, FPT Vietnam, GMO GPU Cloud, Jottacloud, metalstack.cloud, Netskope, Ola Krutrim, Operant, Reliance, Sakura Internet, T-Systems, Wiz, Yotta, Zscaler.
+
+### Customer, Marketing & eCommerce (15 services)
+
+CRM, customer support, marketing automation, and e-commerce infrastructure platforms.
+
+Services: Attio, Beehiiv, Clarify, Customer.io, Formbricks, Front, Helpscout, Hubspot, Jasper, Klaviyo, Mirakl, Plain, Shopify, Stonly, Zendesk.
+
+### Communications, IoT & Media (15 services)
+
+Messaging APIs, email delivery, SMS, voice, video, push notifications, and IoT connectivity platforms.
+
+Services: 1NCE, api.video, Gradium, Hologram, Knock, Mux, Onomondo, Particle, Resend, Samsara, Sendbird, SLNG, Soracom, Twilio, Wistia.
+
+### AI Coding & App Generation (14 services)
+
+AI-assisted code generation, app scaffolding, and developer productivity tools built on LLMs.
+
+Services: Base44, Bolt, Codev, CopilotKit, Cursor, Git AI, GitHub Copilot, Marblism, Mesa, OB-1, Softgen, Tabnine, v0, Windsurf.
+
+### Emerging & Unverified Providers (14 services)
+
+Services that passed automated evaluation but have limited track record or are early-stage. Scored 🟡 (2/3 criteria). Included for discovery; verify independently before production use.
+
+Services: API7, Apigee, Chroma, Eppo, FeatBit, KrakenD, LaunchDarkly, OpenObserve, Oxide Computer, Split, Statsig, Tggl, Turbopuffer, Uptrace.
 
 ### AI Inference & Model APIs (11 services)
 
 Hosted inference APIs for open-source and proprietary models, optimized for speed, cost, and scale.
 
-Key services: Groq, Fireworks.ai, Together AI, Replicate, Roboflow, Portkey, LeptonAI, Parallel, Cloudglue, Nomadic, Anchor.
+Services: Anchor, Cloudglue, Fireworks.ai, Groq, LeptonAI, Nomadic, Parallel, Portkey, Replicate, Roboflow, Together.ai.
+
+### Data Integration & ETL (7 services)
+
+Data pipeline, ETL, CDC, and integration platforms with self-service onboarding.
+
+Services: Airbyte, Arroyo, dbt Labs, Firecrawl, Fivetran, Redpanda, Rivery.
 
 ### Unikernels & WebAssembly (4 services)
 
 Edge computing, WebAssembly runtimes, and unikernel deployment platforms.
 
-Key services: Fermyon, Cosmonic, NanoVMs, Unikraft.
-
-### Source Code Control (3 services)
-
-Git hosting platforms with CI/CD integration and collaboration features.
-
-Key services: GitLab, Gitea Cloud, Sourcehut.
+Services: Cosmonic, KraftCloud, NanoVMs, Wasmer.
 
 ### Cloud Adjacent & Infrastructure Tooling (4 services)
 
 Tools and platforms that extend or manage cloud infrastructure without being cloud providers themselves.
 
-Key services: Pulumi Cloud, Spacelift, env0, Scalr.
+Services: Edgeless Systems, ngrok, Solo.io, Tetrate.
 
-### Decentralized & Web3 Compute (1 service)
+### Source Code Control (3 services)
+
+Git hosting platforms with CI/CD integration and collaboration features.
+
+Services: Gitea Cloud, GitHub, GitLab.
+
+### Decentralized & Web3 Compute (1 services)
 
 Blockchain-based and decentralized compute platforms.
 
-Key services: Akash Network.
-
-### Emerging & Unverified Providers (14 services)
-
-Services that passed automated evaluation but have limited track record or are early-stage. Scored 🟡 (2/3 criteria). Included for discovery; verify independently before production use.
+Services: Akash Network.
 
 ## Submission & Evaluation Pipeline
 
@@ -173,8 +171,9 @@ Services that passed automated evaluation but have limited track record or are e
 
 ## Key Facts
 
-- 419+ services as of April 2026
+- 419+ services as of 2026-04-24
 - 23 categories covering the full developer cloud ecosystem
+- 392 services meet all 3 criteria (🟢); 27 meet 2 of 3 (🟡)
 - Minimum inclusion score: 2/3 criteria
 - Machine-readable data: https://www.alt-cloud.org/clouds.json
 - Source: https://github.com/datum-cloud/awesome-alt-clouds

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,189 @@
+# Awesome Alt Clouds — Full Reference
+
+> Curated directory of 419+ alternative cloud providers for developers who need specialized infrastructure beyond AWS, GCP, and Azure. Each service is independently evaluated against 3 public criteria: transparent pricing, self-service signup, and a public SLA or status page.
+
+## About This Directory
+
+- [Directory Homepage](https://www.alt-cloud.org/): Interactive searchable directory. Filter by category, search by name or description, sort alphabetically, by score, or by recently added date. All data loaded from /clouds.json.
+- [Submit a Service](https://www.alt-cloud.org/submit/): Web form that creates a GitHub issue, triggers automated AI evaluation (pricing page detection, signup detection, status page detection), and opens a PR on pass.
+- [GitHub Repository](https://github.com/datum-cloud/awesome-alt-clouds): Source of truth. Contains README.md (the awesome list), evaluation scripts in /scripts, and GitHub Actions workflows in .github/workflows.
+- [Machine-Readable Data](https://www.alt-cloud.org/clouds.json): JSON array of all entries with fields: name, url, description, score (2 or 3), categories (array), dateAdded (ISO date from git history).
+
+## Evaluation Criteria
+
+Services are scored against 3 criteria. A minimum score of 2/3 is required for inclusion:
+
+1. **Transparent Public Pricing** — a publicly accessible pricing page with actual prices or tiers visible without signing up or contacting sales.
+2. **Usage-Based Self-Service** — ability to sign up and start using the service without sales intervention; includes free trials, free tiers, or pay-as-you-go billing.
+3. **Production Indicators** — a public SLA commitment, status page, or uptime transparency indicator (e.g., statuspage.io, status subdomain).
+
+Score legend: 🟢 = 3/3 criteria met | 🟡 = 2/3 criteria met
+
+## Categories
+
+### Infrastructure Clouds (40 services)
+
+General-purpose cloud compute, bare metal, and VPS providers. The original "alt clouds" offering virtualized compute, dedicated servers, GPU instances, storage, and Kubernetes services outside the hyperscaler ecosystem.
+
+Key services: Digital Ocean, Vultr, Linode, Scaleway, Hetzner, Civo, Latitude.sh, Gcore, OVH Cloud, Rackspace, LeaseWeb, DataPacket, IONOS Cloud, Atlantic.net, Openmetal.io, Servers.com, NetActuate, Salad, Spheron Network, Sustainable Metal Cloud, QBO, Lyceum, E2E Cloud, Hivelocity, Cycle.io, Beam, Driver, exe.dev.
+
+### GPU & AI Compute Clouds (35 services)
+
+Specialized GPU compute platforms for AI training, model fine-tuning, and high-performance workloads. Includes serverless GPU inference, GPU clusters, and distributed compute networks.
+
+Key services: Lambda Labs, Vast.ai, CoreWeave, Together AI, Banana.dev, Baseten, Anyscale, Aethir, Crusoe Energy, Fluidstack, Groq (hardware), Hyperbolic, Runpod, Lepton AI, TensorDock, Genesis Cloud, NVIDIA DGX Cloud, Modal, SF Compute, Nebius, Fal.ai.
+
+### Databases & Storage (35 services)
+
+Managed database services, vector databases, distributed SQL, time series, object storage, and data warehousing — all self-service with public pricing.
+
+Key services: Neon, PlanetScale, CockroachDB, Turso, Xata, Upstash, Railway (Postgres), Supabase, Fly.io Postgres, SingleStore, Timescale, QuestDB, InfluxDB Cloud, Cloudflare R2, Backblaze B2, Storj, Filebase, MinIO Cloud, Tigris, Weaviate, Qdrant, Pinecone, Milvus, Chroma, Zilliz.
+
+### Developer Tooling & CI/CD (34 services)
+
+CI/CD platforms, code hosting, testing infrastructure, feature flags, error monitoring, and developer workflow automation.
+
+Key services: Railway, Render, Fly.io, Deno Deploy, Netlify, Vercel (alt), Cloudflare Workers/Pages, Zeet, Porter, Depot, BuildKite, Semaphore, Earthly, Trunk, Codecov, Sentry (alt), LaunchDarkly, Split.io, Statsig, Unleash, Flipt.
+
+### Authorization, Identity & Fraud (32 services)
+
+Authentication, authorization, identity management, secrets management, and fraud detection services with self-service onboarding.
+
+Key services: Auth0, Clerk, WorkOS, Stytch, Ory, Keycloak, FusionAuth, Descope, PropelAuth, Frontegg, JumpCloud, Okta (alt tiers), Duo, Pangea, Permit.io, Oso, Pomerium, Doppler, Infisical, HashiCorp Vault Cloud, Sift Science.
+
+### Observability & Monitoring (25 services)
+
+Logging, metrics, tracing, APM, uptime monitoring, and error tracking platforms with pay-as-you-go or free tiers.
+
+Key services: Datadog (alt tiers), Grafana Cloud, New Relic, Honeycomb, Axiom, Highlight, OpenObserve, Signoz, Mezmo, Coralogix, Better Uptime, Checkly, Cronitor, Oh Dear, Pagerduty, Incident.io, Rootly, FireHydrant.
+
+### AI Assistants & Copilots (23 services)
+
+AI assistant platforms, copilot APIs, and conversational AI services for building customer-facing or developer-facing intelligent experiences.
+
+Key services: Anthropic Claude API, OpenAI (alt tiers), Cohere, AI21 Labs, Mistral AI, Perplexity API, You.com API, Kapa.ai, Mendable, Chatbase, Dust, Superagent, Relevance AI.
+
+### Network & Connectivity Clouds (22 services)
+
+CDN, edge networking, DNS, DDoS protection, VPN, and private networking platforms.
+
+Key services: Cloudflare, Fastly, BunnyCDN, KeyCDN, Fly.io networking, Tailscale, ZeroTier, Netbird, Headscale, Ngrok, Cloudflare Tunnel, NS1, DNSimple, Route 53 (alt), Vercara.
+
+### Monetization & Billing Clouds (21 services)
+
+Payment processing, subscription management, usage-based billing, metering, and revenue operations platforms.
+
+Key services: Stripe, Paddle, Lago, OpenMeter, Amberflo, Metronome, Orb, Stigg, Chargebee, Recurly, Maxio, Autumn, Useautumn, Paymongo, Lemon Squeezy.
+
+### Customer, Marketing & eCommerce (15 services)
+
+CRM, customer support, marketing automation, and e-commerce infrastructure platforms.
+
+Key services: Plain, Helpscout, Zendesk (alt tiers), Front, Hubspot (alt), Customer.io, Attio, Clarify, Klaviyo, Stonly, Jasper, Beehiiv, Shopify, Mirakl, Formbricks.
+
+### AI Coding & App Generation (14 services)
+
+AI-assisted code generation, app scaffolding, and developer productivity tools built on LLMs.
+
+Key services: GitHub Copilot (alt), Tabnine, Codeium, Cursor, Continue, Sourcegraph Cody, Replit AI, Bolt.new, Lovable, v0, Devin, SWE-agent.
+
+### PaaS & Application Hosting (17 services)
+
+Platform-as-a-service offerings for deploying web applications, APIs, and backend services with minimal infrastructure management.
+
+Key services: Heroku (alt tiers), Railway, Render, Fly.io, Porter, Zeet, Back4app, Koyeb, Adaptable.io, Northflank, Qoddi, Coolify, CapRover, Caprover.
+
+### Security, Compliance & Sovereignty Clouds (15 services)
+
+Security-focused cloud platforms with compliance certifications, data sovereignty options, air-gapped deployments, and sovereign cloud infrastructure.
+
+Key services: Hetzner (GDPR), OVH (French sovereignty), Exoscale, Cleura, STACKIT, Open Telekom Cloud, Bluvalt, T-Systems, Cipherstack, Idrivee2, Wasabi (compliance), Backblaze (HIPAA).
+
+### Communications, IoT & Media (15 services)
+
+Messaging APIs, email delivery, SMS, voice, video, push notifications, and IoT connectivity platforms.
+
+Key services: Twilio (alt tiers), Vonage/Nexmo, MessageBird, Sinch, Plivo, Telnyx, Postmark, Sendgrid (alt), Mailgun, Resend, Knock, Courier, Novu, Ably, Pusher.
+
+### Observability & Monitoring (25 services)
+
+See category details above.
+
+### Analytics & Data Warehousing (16 services)
+
+Cloud data warehouses, analytics databases, business intelligence platforms, and data lakehouse services.
+
+Key services: MotherDuck, Tinybird, ClickHouse Cloud, Firebolt, StarRocks Cloud, Hydra, Databend, DuckDB Cloud, Plandek, Redpanda Cloud.
+
+### Workflow & Operations Clouds (16 services)
+
+Workflow orchestration, job queues, event streaming, and operations automation platforms.
+
+Key services: Inngest, Temporal Cloud, Trigger.dev, Zeplo, Winglang, Upstash Qstash, Quirrel, Windmill, n8n Cloud, Make (Integromat), Pipedream, Tray.io.
+
+### Data Integration & ETL (7 services)
+
+Data pipeline, ETL, CDC, and integration platforms with self-service onboarding.
+
+Key services: Airbyte Cloud, Fivetran (alt tiers), Stitch, Segment (alt), Hightouch, Census, Polytomic, Firecrawl.
+
+### AI Inference & Model APIs (11 services)
+
+Hosted inference APIs for open-source and proprietary models, optimized for speed, cost, and scale.
+
+Key services: Groq, Fireworks.ai, Together AI, Replicate, Roboflow, Portkey, LeptonAI, Parallel, Cloudglue, Nomadic, Anchor.
+
+### Unikernels & WebAssembly (4 services)
+
+Edge computing, WebAssembly runtimes, and unikernel deployment platforms.
+
+Key services: Fermyon, Cosmonic, NanoVMs, Unikraft.
+
+### Source Code Control (3 services)
+
+Git hosting platforms with CI/CD integration and collaboration features.
+
+Key services: GitLab, Gitea Cloud, Sourcehut.
+
+### Cloud Adjacent & Infrastructure Tooling (4 services)
+
+Tools and platforms that extend or manage cloud infrastructure without being cloud providers themselves.
+
+Key services: Pulumi Cloud, Spacelift, env0, Scalr.
+
+### Decentralized & Web3 Compute (1 service)
+
+Blockchain-based and decentralized compute platforms.
+
+Key services: Akash Network.
+
+### Emerging & Unverified Providers (14 services)
+
+Services that passed automated evaluation but have limited track record or are early-stage. Scored 🟡 (2/3 criteria). Included for discovery; verify independently before production use.
+
+## Submission & Evaluation Pipeline
+
+- Submission form at https://www.alt-cloud.org/submit/ creates a GitHub issue
+- For single-URL submissions: evaluate-submission.yml workflow runs automatically
+- For multi-URL submissions: split-submission.yml creates one child issue per URL, evaluates each independently
+- Evaluation uses Python scripts with web scraping (Jina Reader + requests) and Claude AI for metadata generation
+- Passing services (score ≥ 2) get an automatic PR; failing services get a needs-review label for admin override
+- Admin override: comment `/approve 3` on any issue to force-approve with score override
+- clouds.json is regenerated on every PR merge; dateAdded comes from git history
+
+## Key Facts
+
+- 419+ services as of April 2026
+- 23 categories covering the full developer cloud ecosystem
+- Minimum inclusion score: 2/3 criteria
+- Machine-readable data: https://www.alt-cloud.org/clouds.json
+- Source: https://github.com/datum-cloud/awesome-alt-clouds
+- License: CC BY 4.0
+- Maintained by: Datum Cloud (https://github.com/datum-cloud)
+- Accepts community submissions via https://www.alt-cloud.org/submit/
+
+## Contact
+
+- Website: https://www.alt-cloud.org
+- GitHub Issues: https://github.com/datum-cloud/awesome-alt-clouds/issues
+- Submit a service: https://www.alt-cloud.org/submit/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,30 @@
+# Awesome Alt Clouds
+
+> Curated directory of 419+ alternative cloud providers for developers — covering infrastructure, GPU compute, databases, AI inference, observability, developer tooling, and more. Each service is evaluated against 3 public criteria.
+
+## Directory
+
+- [Full Cloud Directory](https://www.alt-cloud.org/): Interactive directory of 419+ alternative cloud providers across 23 categories. Filter by category, search by name, sort by score or recently added.
+- [Submit a Cloud Service](https://www.alt-cloud.org/submit/): Form to submit a new cloud service for automated evaluation and inclusion in the directory.
+
+## Data
+
+- [clouds.json](https://www.alt-cloud.org/clouds.json): Machine-readable JSON file with all 419+ entries including name, URL, description, score (2 or 3), categories, and dateAdded. Updated automatically on each PR merge.
+- [README (Awesome List)](https://raw.githubusercontent.com/datum-cloud/awesome-alt-clouds/main/README.md): Canonical markdown source of the directory, organized by category with scoring badges. Hosted on GitHub.
+- [GitHub Repository](https://github.com/datum-cloud/awesome-alt-clouds): Source repository. Contains submission workflows, evaluation scripts, and contribution guidelines.
+
+## Key Facts
+
+- 419+ cloud services listed across 23 categories
+- Services must meet at least 2 of 3 criteria to be included: (1) transparent public pricing, (2) usage-based self-service signup, (3) public SLA or status page
+- Score legend: 🟢 = all 3 criteria met, 🟡 = 2 of 3 criteria met
+- Automated submission pipeline: form → GitHub issue → AI evaluation → PR → merge
+- Largest categories: Infrastructure Clouds (40), GPU & AI Compute Clouds (35), Databases & Storage (35), Developer Tooling & CI/CD (34), Authorization Identity & Fraud (32)
+- Community-maintained; maintained by Datum Cloud
+- Data available as JSON at /clouds.json and Markdown on GitHub
+
+## Contact
+
+- Website: https://www.alt-cloud.org
+- GitHub: https://github.com/datum-cloud/awesome-alt-clouds
+- Submit: https://www.alt-cloud.org/submit/

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Awesome Alt Clouds
 
-> Curated directory of 419+ alternative cloud providers for developers — covering infrastructure, GPU compute, databases, AI inference, observability, developer tooling, and more. Each service is evaluated against 3 public criteria.
+> Curated directory of 419+ alternative cloud providers for developers — covering 23 categories including infrastructure, GPU compute, databases, AI inference, observability, developer tooling, and more. Each service is evaluated against 3 public criteria.
 
 ## Directory
 
@@ -19,7 +19,7 @@
 - Services must meet at least 2 of 3 criteria to be included: (1) transparent public pricing, (2) usage-based self-service signup, (3) public SLA or status page
 - Score legend: 🟢 = all 3 criteria met, 🟡 = 2 of 3 criteria met
 - Automated submission pipeline: form → GitHub issue → AI evaluation → PR → merge
-- Largest categories: Infrastructure Clouds (40), GPU & AI Compute Clouds (35), Databases & Storage (35), Developer Tooling & CI/CD (34), Authorization Identity & Fraud (32)
+- Largest categories: Infrastructure Clouds (40), GPU & AI Compute Clouds (35), Databases & Storage (35), Developer Tooling & CI/CD (34), Authorization, Identity & Fraud (32)
 - Community-maintained; maintained by Datum Cloud
 - Data available as JSON at /clouds.json and Markdown on GitHub
 

--- a/scripts/generate_llms.py
+++ b/scripts/generate_llms.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Generate docs/llms.txt and docs/llms-full.txt from docs/clouds.json.
+
+Called by deploy-pages.yml after clouds.json is regenerated so that
+AI-readable files always reflect the current state of the directory.
+
+Usage:
+    python scripts/generate_llms.py [clouds.json] [output_dir]
+
+Defaults:
+    clouds.json  → docs/clouds.json
+    output_dir   → docs/
+"""
+
+import json
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Static content blocks (not derived from clouds.json)
+# ---------------------------------------------------------------------------
+
+_CRITERIA_BLOCK = """\
+## Evaluation Criteria
+
+Services are scored against 3 criteria. A minimum score of 2/3 is required for inclusion:
+
+1. **Transparent Public Pricing** — a publicly accessible pricing page with actual prices or tiers visible without signing up or contacting sales.
+2. **Usage-Based Self-Service** — ability to sign up and start using the service without sales intervention; includes free trials, free tiers, or pay-as-you-go billing.
+3. **Production Indicators** — a public SLA commitment, status page, or uptime transparency indicator (e.g. statuspage.io, status subdomain).
+
+Score legend: 🟢 = 3/3 criteria met | 🟡 = 2/3 criteria met"""
+
+_PIPELINE_BLOCK = """\
+## Submission & Evaluation Pipeline
+
+- Submission form at https://www.alt-cloud.org/submit/ creates a GitHub issue
+- For single-URL submissions: evaluate-submission.yml workflow runs automatically
+- For multi-URL submissions: split-submission.yml creates one child issue per URL, evaluates each independently
+- Evaluation uses Python scripts with web scraping (Jina Reader + requests) and Claude AI for metadata generation
+- Passing services (score ≥ 2) get an automatic PR; failing services get a needs-review label for admin override
+- Admin override: comment `/approve 3` on any issue to force-approve with score override
+- clouds.json is regenerated on every PR merge; dateAdded comes from git history"""
+
+_CONTACT_BLOCK = """\
+## Contact
+
+- Website: https://www.alt-cloud.org
+- GitHub Issues: https://github.com/datum-cloud/awesome-alt-clouds/issues
+- Submit a service: https://www.alt-cloud.org/submit/"""
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+def load_clouds(path: Path) -> list[dict]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def category_stats(clouds: list[dict]) -> list[tuple[str, int, list[str]]]:
+    """Return list of (category, count, [top service names]) sorted by count desc."""
+    cat_entries: dict[str, list[str]] = defaultdict(list)
+    for c in clouds:
+        for cat in c.get("categories", []):
+            cat_entries[cat].append(c["name"])
+
+    result = []
+    for cat, names in cat_entries.items():
+        result.append((cat, len(names), names))
+    result.sort(key=lambda x: -x[1])
+    return result
+
+
+# ---------------------------------------------------------------------------
+# llms.txt generator
+# ---------------------------------------------------------------------------
+
+def generate_llms_txt(clouds: list[dict]) -> str:
+    total = len(clouds)
+    stats = category_stats(clouds)
+    num_cats = len(stats)
+    top5 = ", ".join(f"{cat} ({n})" for cat, n, _ in stats[:5])
+
+    lines = [
+        "# Awesome Alt Clouds",
+        "",
+        f"> Curated directory of {total}+ alternative cloud providers for developers — covering {num_cats} categories including infrastructure, GPU compute, databases, AI inference, observability, developer tooling, and more. Each service is evaluated against 3 public criteria.",
+        "",
+        "## Directory",
+        "",
+        "- [Full Cloud Directory](https://www.alt-cloud.org/): Interactive directory of "
+        f"{total}+ alternative cloud providers across {num_cats} categories. "
+        "Filter by category, search by name, sort by score or recently added.",
+        "- [Submit a Cloud Service](https://www.alt-cloud.org/submit/): Form to submit a new cloud service for automated evaluation and inclusion in the directory.",
+        "",
+        "## Data",
+        "",
+        "- [clouds.json](https://www.alt-cloud.org/clouds.json): Machine-readable JSON file with all "
+        f"{total}+ entries including name, URL, description, score (2 or 3), categories, and dateAdded. "
+        "Updated automatically on each PR merge.",
+        "- [README (Awesome List)](https://raw.githubusercontent.com/datum-cloud/awesome-alt-clouds/main/README.md): "
+        "Canonical markdown source of the directory, organized by category with scoring badges. Hosted on GitHub.",
+        "- [GitHub Repository](https://github.com/datum-cloud/awesome-alt-clouds): "
+        "Source repository. Contains submission workflows, evaluation scripts, and contribution guidelines.",
+        "",
+        "## Key Facts",
+        "",
+        f"- {total}+ cloud services listed across {num_cats} categories",
+        "- Services must meet at least 2 of 3 criteria to be included: "
+        "(1) transparent public pricing, (2) usage-based self-service signup, (3) public SLA or status page",
+        "- Score legend: 🟢 = all 3 criteria met, 🟡 = 2 of 3 criteria met",
+        "- Automated submission pipeline: form → GitHub issue → AI evaluation → PR → merge",
+        f"- Largest categories: {top5}",
+        "- Community-maintained; maintained by Datum Cloud",
+        "- Data available as JSON at /clouds.json and Markdown on GitHub",
+        "",
+        "## Contact",
+        "",
+        "- Website: https://www.alt-cloud.org",
+        "- GitHub: https://github.com/datum-cloud/awesome-alt-clouds",
+        "- Submit: https://www.alt-cloud.org/submit/",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# llms-full.txt generator
+# ---------------------------------------------------------------------------
+
+# Category descriptions (static; keyed by exact category name)
+_CAT_DESCRIPTIONS: dict[str, str] = {
+    "Infrastructure Clouds": (
+        "General-purpose cloud compute, bare metal, and VPS providers. "
+        "The original \"alt clouds\" offering virtualized compute, dedicated servers, "
+        "GPU instances, storage, and Kubernetes services outside the hyperscaler ecosystem."
+    ),
+    "GPU & AI Compute Clouds": (
+        "Specialized GPU compute platforms for AI training, model fine-tuning, and "
+        "high-performance workloads. Includes serverless GPU inference, GPU clusters, "
+        "and distributed compute networks."
+    ),
+    "Databases & Storage": (
+        "Managed database services, vector databases, distributed SQL, time series, "
+        "object storage, and data warehousing — all self-service with public pricing."
+    ),
+    "Developer Tooling & CI/CD": (
+        "CI/CD platforms, code hosting, testing infrastructure, feature flags, "
+        "error monitoring, and developer workflow automation."
+    ),
+    "Authorization, Identity & Fraud": (
+        "Authentication, authorization, identity management, secrets management, "
+        "and fraud detection services with self-service onboarding."
+    ),
+    "Observability & Monitoring": (
+        "Logging, metrics, tracing, APM, uptime monitoring, and error tracking "
+        "platforms with pay-as-you-go or free tiers."
+    ),
+    "AI Assistants & Copilots": (
+        "AI assistant platforms, copilot APIs, and conversational AI services for "
+        "building customer-facing or developer-facing intelligent experiences."
+    ),
+    "Network & Connectivity Clouds": (
+        "CDN, edge networking, DNS, DDoS protection, VPN, and private networking platforms."
+    ),
+    "Monetization & Billing Clouds": (
+        "Payment processing, subscription management, usage-based billing, metering, "
+        "and revenue operations platforms."
+    ),
+    "Customer, Marketing & eCommerce": (
+        "CRM, customer support, marketing automation, and e-commerce infrastructure platforms."
+    ),
+    "AI Coding & App Generation": (
+        "AI-assisted code generation, app scaffolding, and developer productivity "
+        "tools built on LLMs."
+    ),
+    "PaaS & Application Hosting": (
+        "Platform-as-a-service offerings for deploying web applications, APIs, and "
+        "backend services with minimal infrastructure management."
+    ),
+    "Security, Compliance & Sovereignty Clouds": (
+        "Security-focused cloud platforms with compliance certifications, data "
+        "sovereignty options, air-gapped deployments, and sovereign cloud infrastructure."
+    ),
+    "Communications, IoT & Media": (
+        "Messaging APIs, email delivery, SMS, voice, video, push notifications, "
+        "and IoT connectivity platforms."
+    ),
+    "Analytics & Data Warehousing": (
+        "Cloud data warehouses, analytics databases, business intelligence platforms, "
+        "and data lakehouse services."
+    ),
+    "Workflow & Operations Clouds": (
+        "Workflow orchestration, job queues, event streaming, and operations "
+        "automation platforms."
+    ),
+    "Data Integration & ETL": (
+        "Data pipeline, ETL, CDC, and integration platforms with self-service onboarding."
+    ),
+    "AI Inference & Model APIs": (
+        "Hosted inference APIs for open-source and proprietary models, optimized "
+        "for speed, cost, and scale."
+    ),
+    "Unikernels & WebAssembly": (
+        "Edge computing, WebAssembly runtimes, and unikernel deployment platforms."
+    ),
+    "Source Code Control": (
+        "Git hosting platforms with CI/CD integration and collaboration features."
+    ),
+    "Cloud Adjacent & Infrastructure Tooling": (
+        "Tools and platforms that extend or manage cloud infrastructure without "
+        "being cloud providers themselves."
+    ),
+    "Decentralized & Web3 Compute": (
+        "Blockchain-based and decentralized compute platforms."
+    ),
+    "Emerging & Unverified Providers": (
+        "Services that passed automated evaluation but have limited track record or "
+        "are early-stage. Scored 🟡 (2/3 criteria). Included for discovery; "
+        "verify independently before production use."
+    ),
+}
+
+_DEFAULT_CAT_DESCRIPTION = "Cloud services in this category."
+
+
+def generate_llms_full_txt(clouds: list[dict]) -> str:
+    total = len(clouds)
+    stats = category_stats(clouds)
+    num_cats = len(stats)
+    today = date.today().isoformat()
+
+    sections: list[str] = []
+
+    # Header
+    sections.append("# Awesome Alt Clouds — Full Reference")
+    sections.append("")
+    sections.append(
+        f"> Curated directory of {total}+ alternative cloud providers for developers who need "
+        "specialized infrastructure beyond AWS, GCP, and Azure. Each service is independently "
+        "evaluated against 3 public criteria: transparent pricing, self-service signup, and a "
+        "public SLA or status page."
+    )
+    sections.append("")
+
+    # About
+    sections.append("## About This Directory")
+    sections.append("")
+    sections.append(
+        "- [Directory Homepage](https://www.alt-cloud.org/): Interactive searchable directory. "
+        "Filter by category, search by name or description, sort alphabetically, by score, or by "
+        "recently added date. All data loaded from /clouds.json."
+    )
+    sections.append(
+        "- [Submit a Service](https://www.alt-cloud.org/submit/): Web form that creates a GitHub "
+        "issue, triggers automated AI evaluation (pricing page detection, signup detection, status "
+        "page detection), and opens a PR on pass."
+    )
+    sections.append(
+        "- [GitHub Repository](https://github.com/datum-cloud/awesome-alt-clouds): Source of truth. "
+        "Contains README.md (the awesome list), evaluation scripts in /scripts, and GitHub Actions "
+        "workflows in .github/workflows."
+    )
+    sections.append(
+        f"- [Machine-Readable Data](https://www.alt-cloud.org/clouds.json): JSON array of all "
+        f"{total}+ entries with fields: name, url, description, score (2 or 3), categories (array), "
+        "dateAdded (ISO date from git history)."
+    )
+    sections.append("")
+
+    # Criteria
+    sections.append(_CRITERIA_BLOCK)
+    sections.append("")
+
+    # Categories
+    sections.append("## Categories")
+    sections.append("")
+
+    for cat, count, names in stats:
+        desc = _CAT_DESCRIPTIONS.get(cat, _DEFAULT_CAT_DESCRIPTION)
+        # Up to 15 key service names
+        key_services = ", ".join(names[:15])
+        if len(names) > 15:
+            key_services += f", and {len(names) - 15} more"
+        sections.append(f"### {cat} ({count} services)")
+        sections.append("")
+        sections.append(desc)
+        sections.append("")
+        sections.append(f"Services: {key_services}.")
+        sections.append("")
+
+    # Pipeline
+    sections.append(_PIPELINE_BLOCK)
+    sections.append("")
+
+    # Key facts
+    score3 = sum(1 for c in clouds if c.get("score", 3) == 3)
+    score2 = sum(1 for c in clouds if c.get("score", 3) == 2)
+
+    sections.append("## Key Facts")
+    sections.append("")
+    sections.append(f"- {total}+ services as of {today}")
+    sections.append(f"- {num_cats} categories covering the full developer cloud ecosystem")
+    sections.append(f"- {score3} services meet all 3 criteria (🟢); {score2} meet 2 of 3 (🟡)")
+    sections.append("- Minimum inclusion score: 2/3 criteria")
+    sections.append("- Machine-readable data: https://www.alt-cloud.org/clouds.json")
+    sections.append("- Source: https://github.com/datum-cloud/awesome-alt-clouds")
+    sections.append("- License: CC BY 4.0")
+    sections.append("- Maintained by: Datum Cloud (https://github.com/datum-cloud)")
+    sections.append("- Accepts community submissions via https://www.alt-cloud.org/submit/")
+    sections.append("")
+
+    # Contact
+    sections.append(_CONTACT_BLOCK)
+
+    return "\n".join(sections) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    clouds_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("docs/clouds.json")
+    output_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("docs")
+
+    if not clouds_path.exists():
+        print(f"ERROR: {clouds_path} not found", file=sys.stderr)
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    clouds = load_clouds(clouds_path)
+    total = len(clouds)
+    print(f"Loaded {total} services from {clouds_path}")
+
+    llms_path = output_dir / "llms.txt"
+    llms_path.write_text(generate_llms_txt(clouds))
+    print(f"✅ Generated {llms_path}")
+
+    llms_full_path = output_dir / "llms-full.txt"
+    llms_full_path.write_text(generate_llms_full_txt(clouds))
+    print(f"✅ Generated {llms_full_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parse_readme_to_json.py
+++ b/scripts/parse_readme_to_json.py
@@ -10,6 +10,60 @@ categories array.
 
 import json
 import re
+import subprocess
+
+
+# Regex shared between the parser and the git history walker
+_ENTRY_RE = re.compile(r'^\+?\s*\*\s*(🟢|🟡)?\s*\[([^\]]+)\]\(([^)]+)\)\s+-\s+(.+)$')
+
+
+def _build_date_added_map(readme_path: str) -> dict[str, str]:
+    """Return a mapping of URL -> ISO date string of first git commit that added it.
+
+    Walks the full git log for readme_path in reverse (oldest-first) order,
+    scanning diff additions (+lines) for entry URLs.  The first time a URL
+    appears in an addition line is recorded as its dateAdded.
+    """
+    try:
+        result = subprocess.run(
+            [
+                'git', 'log',
+                '--reverse',                 # oldest → newest
+                '--pretty=format:COMMIT_DATE:%ad',
+                '--date=short',              # YYYY-MM-DD
+                '-p',                        # include patch
+                '--',
+                readme_path,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=None,  # inherit CWD
+        )
+    except FileNotFoundError:
+        # git not available (e.g. running outside a repo)
+        return {}
+
+    if result.returncode != 0 or not result.stdout:
+        return {}
+
+    date_map: dict[str, str] = {}
+    current_date: str | None = None
+
+    for line in result.stdout.splitlines():
+        if line.startswith('COMMIT_DATE:'):
+            current_date = line[len('COMMIT_DATE:'):]
+            continue
+        # Only look at added lines in the diff
+        if not line.startswith('+') or line.startswith('+++'):
+            continue
+        m = _ENTRY_RE.match(line)
+        if not m:
+            continue
+        url = m.group(3)
+        if url not in date_map and current_date:
+            date_map[url] = current_date
+
+    return date_map
 
 
 def parse_readme(readme_path):
@@ -17,6 +71,8 @@ def parse_readme(readme_path):
 
     with open(readme_path, 'r') as f:
         content = f.read()
+
+    date_map = _build_date_added_map(readme_path)
 
     # url → entry dict (for deduplication)
     seen = {}
@@ -55,6 +111,8 @@ def parse_readme(readme_path):
                 'score': score,
                 'categories': [current_category],
             }
+            if url in date_map:
+                entry['dateAdded'] = date_map[url]
             seen[url] = entry
             order.append(url)
 


### PR DESCRIPTION
## Summary

- **`dateAdded` in clouds.json** — `parse_readme_to_json.py` now walks git history to find when each URL was first committed to README.md and stores it as `dateAdded`. Fixes the _Recently Added_ sort on the directory (previously had no data to sort on).
- **JSON-LD structured data** — adds `@graph` to `docs/index.html` with `WebSite`, `Organization` (Datum Cloud), `Dataset` (with `clouds.json` and README as `DataDownload`), and `CollectionPage` schemas. Also fixes OG/Twitter URLs (`github.io` → `alt-cloud.org`) and adds a canonical link.
- **`llms.txt` + `llms-full.txt`** — AI-readable site summaries served at `/llms.txt` and `/llms-full.txt`. Auto-generated from `clouds.json` by `scripts/generate_llms.py` (called by `deploy-pages.yml` after every README change).

## Files changed

| File | Change |
|------|--------|
| `scripts/parse_readme_to_json.py` | Add git-history walk to populate `dateAdded` |
| `docs/index.html` | JSON-LD `@graph`, canonical, OG/Twitter URL fix |
| `docs/llms.txt` | New — generated from clouds.json |
| `docs/llms-full.txt` | New — generated from clouds.json (per-category detail) |
| `docs/clouds.json` | Regenerated with `dateAdded` on all 419 entries |

> Note: `deploy-pages.yml` change (calls `generate_llms.py`) was applied directly via browser due to workflow file protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)