### PR TITLE
feat: URL routing + AI category restructure

### DIFF
--- a/docs/clouds.json
+++ b/docs/clouds.json
@@ -2265,7 +2265,7 @@
     "description": "Offers powerful speech-to-text and AI APIs for transcription, summarization, content moderation, and more.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2325,7 +2325,7 @@
     "description": "Enterprise AI platform with language models for automation, data insights, and custom solutions.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2335,7 +2335,7 @@
     "description": "Offers a suite of open AI APIs for developers, including text, image, and moderation tools.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2345,7 +2345,7 @@
     "description": "Provides developer tools and research models for AI-powered coding, content generation, and reasoning tasks.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2355,7 +2355,7 @@
     "description": "AI text-to-speech with ultra-realistic voices in 32+ languages, voice cloning, and conversational agents.",
     "score": 3,
     "categories": [
-      "AI Assistants & Copilots"
+      "AI Inference & Model APIs"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2495,7 +2495,7 @@
     "description": "An all-in-one AI platform to easily build fully functioning apps without coding.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "AI App Builders"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2505,7 +2505,7 @@
     "description": "A browser-based AI development environment that lets you generate, edit, and deploy full-stack applications instantly using natural language prompts.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "AI App Builders"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2515,7 +2515,7 @@
     "description": "A development assistant that uses AI to generate, analyze, and debug software code efficiently.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2525,7 +2525,7 @@
     "description": "Open-source framework and infrastructure for building in-app AI copilots and agents.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2535,7 +2535,7 @@
     "description": "An AI-enhanced code editor that integrates directly with your codebase to provide suggestions and automate changes.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2545,7 +2545,7 @@
     "description": "Provides open-source Git extension for tracking AI-generated code through the entire software development lifecycle with attribution, context storage, and team analytics.",
     "score": 2,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2026-03-31"
   },
@@ -2555,7 +2555,7 @@
     "description": "An AI-powered coding assistant developed by GitHub and OpenAI that suggests code snippets as you type.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2565,7 +2565,7 @@
     "description": "Generate full-stack web apps from a single prompt.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "AI App Builders"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2575,7 +2575,7 @@
     "description": "AI-powered code review platform with custom agents that learn codebase standards and prevent tech debt.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2585,7 +2585,7 @@
     "description": "Provides a self-improving coding agent that handles the full development lifecycle from project management to pull requests, with multi-model AI support and workflow automation.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2026-03-31"
   },
@@ -2595,7 +2595,7 @@
     "description": "Provides tools to automatically generate code, documentation, and tests to speed up software delivery.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "AI App Builders"
     ],
     "dateAdded": "2025-05-05"
   },
@@ -2605,7 +2605,7 @@
     "description": "AI code assistant with private model options.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2615,7 +2615,7 @@
     "description": "AI-powered UI generation from text prompts to React code.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "AI App Builders"
     ],
     "dateAdded": "2026-01-29"
   },
@@ -2625,7 +2625,7 @@
     "description": "An AI powered coding engine and IDE that is an alternative to GitHub Copilot. Formerly Codeium.",
     "score": 3,
     "categories": [
-      "AI Coding & App Generation"
+      "Agent Labs"
     ],
     "dateAdded": "2025-05-05"
   },

--- a/docs/index.html
+++ b/docs/index.html
@@ -1514,6 +1514,40 @@
       }
     });
 
+    // URL routing helpers
+    function categoryToSlug(cat) {
+      return cat.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    }
+
+    function slugToCategory(slug) {
+      const categories = getCategories();
+      return categories.find(c => categoryToSlug(c) === slug) || 'All';
+    }
+
+    function updateUrl() {
+      const params = new URLSearchParams();
+      if (searchTerm) params.set('search', searchTerm);
+      const hash = currentCategory === 'All' ? '' : '#' + categoryToSlug(currentCategory);
+      const qs = params.toString() ? '?' + params.toString() : '';
+      history.replaceState(null, '', window.location.pathname + qs + hash);
+    }
+
+    function initStateFromUrl() {
+      const params = new URLSearchParams(window.location.search);
+      const searchParam = params.get('search') || '';
+      const hashSlug = window.location.hash.slice(1);
+
+      if (searchParam) {
+        searchTerm = searchParam;
+        document.getElementById('searchInput').value = searchParam;
+        document.getElementById('searchInputMobile').value = searchParam;
+      }
+      if (hashSlug) {
+        const matched = slugToCategory(hashSlug);
+        if (matched !== 'All') currentCategory = matched;
+      }
+    }
+
     // Sort function
     function handleSort() {
       currentSort = document.getElementById('sortSelect').value;
@@ -1560,6 +1594,7 @@
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         altClouds = await response.json();
+        initStateFromUrl();
         renderCategories();
         renderClouds();
       } catch (error) {
@@ -1706,16 +1741,32 @@
       currentCategory = category;
       renderCategories();
       renderClouds();
+      updateUrl();
       closeDrawer();
     }
 
     document.getElementById('searchInput').addEventListener('input', (e) => {
       searchTerm = e.target.value;
+      document.getElementById('searchInputMobile').value = searchTerm;
       renderClouds();
+      updateUrl();
     });
 
     document.getElementById('searchInputMobile').addEventListener('input', (e) => {
       searchTerm = e.target.value;
+      document.getElementById('searchInput').value = searchTerm;
+      renderClouds();
+      updateUrl();
+    });
+
+    window.addEventListener('popstate', () => {
+      const params = new URLSearchParams(window.location.search);
+      searchTerm = params.get('search') || '';
+      document.getElementById('searchInput').value = searchTerm;
+      document.getElementById('searchInputMobile').value = searchTerm;
+      const hashSlug = window.location.hash.slice(1);
+      currentCategory = hashSlug ? slugToCategory(hashSlug) : 'All';
+      renderCategories();
       renderClouds();
     });
 


### PR DESCRIPTION
## Summary

- Category filter now updates the URL hash (e.g. `#databases-storage`); search updates `?search=` query param — both are restored on page load and work with browser back/forward
- Retired "AI Coding & App Generation" in favour of two clearer categories: **Agent Labs** (agentic coding tools) and **AI App Builders** (prompt-to-app tools)
- Moved Cohere, DeepAI, Deepseek, AssemblyAI, ElevenLabs from "AI Assistants & Copilots" → "AI Inference & Model APIs"

Closes #174

## Test plan

- [ ] Visit `/#databases-storage` — should land on Databases & Storage filtered
- [ ] Visit `/?search=cursor` — should show Cursor in results
- [ ] Visit `/?search=gpu#gpu-ai-compute-clouds` — should apply both filters
- [ ] Click a category, copy URL, open in new tab — state restored correctly
- [ ] Browser back/forward navigates between filter states
- [ ] Verify Agent Labs, AI App Builders appear in sidebar with correct entries
- [ ] Verify "AI Coding & App Generation" no longer appears
- [ ] Check Cohere, ElevenLabs etc. appear under AI Inference & Model APIs