### PR TITLE
Switch automation to use a GitHub App token

### DIFF
--- a/.github/workflows/admin-approve-submission.yml
+++ b/.github/workflows/admin-approve-submission.yml
@@ -18,10 +18,18 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Check if user is admin/maintainer
         id: check-permission
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
@@ -49,6 +57,7 @@ jobs:
         id: parse
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const comment = context.payload.comment.body.trim();
             // Match formats:
@@ -108,6 +117,8 @@ jobs:
       - name: Checkout
         if: steps.check-permission.outputs.allowed == 'true' && steps.parse.outputs.valid == 'true'
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         if: steps.check-permission.outputs.allowed == 'true' && steps.parse.outputs.valid == 'true'
@@ -145,7 +156,7 @@ jobs:
       - name: Create PR
         if: steps.check-permission.outputs.allowed == 'true' && steps.parse.outputs.valid == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "=== Debug: Checking for submission_data.json ==="
@@ -166,6 +177,7 @@ jobs:
         if: steps.check-permission.outputs.allowed == 'true' && steps.parse.outputs.valid == 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Remove old labels
             const labelsToRemove = ['needs-review', 'rejected'];

--- a/.github/workflows/close-issue-on-pr-close.yml
+++ b/.github/workflows/close-issue-on-pr-close.yml
@@ -12,9 +12,17 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Close linked issue and check parent tracking issue
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prBody = context.payload.pull_request.body || '';
             const prMerged = context.payload.pull_request.merged;

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -15,8 +15,17 @@ jobs:
       contents: write
     
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
         
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -18,6 +18,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Skip multi-URL submissions (handled by split-submission workflow)
         id: guard
         env:
@@ -34,6 +41,8 @@ jobs:
       - name: Checkout
         if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         if: steps.guard.outputs.skip != 'true'
@@ -53,7 +62,7 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           python scripts/check_duplicates.py
@@ -83,6 +92,7 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const results = fs.readFileSync('evaluation_results.md', 'utf8');
@@ -98,6 +108,7 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const score = parseInt(fs.readFileSync('evaluation_score.txt', 'utf8').trim());
@@ -139,7 +150,7 @@ jobs:
       - name: Create PR if score >= 2
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true' && fromJSON(steps.read_outputs.outputs.score) >= 2 && steps.read_outputs.outputs.has_data == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           python scripts/create_submission_pr.py

--- a/.github/workflows/split-submission.yml
+++ b/.github/workflows/split-submission.yml
@@ -19,6 +19,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Count submitted URLs
         id: url-count
         env:
@@ -38,6 +45,8 @@ jobs:
       - name: Checkout
         if: steps.url-count.outputs.is_multi == 'true'
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         if: steps.url-count.outputs.is_multi == 'true'
@@ -55,6 +64,6 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python scripts/split_submission.py

--- a/.github/workflows/update-blog-posts.yml
+++ b/.github/workflows/update-blog-posts.yml
@@ -14,8 +14,17 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,4 +60,4 @@ jobs:
             --head "$BRANCH" \
             --label "automated" || true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What's changing

Our automation workflows now use a dedicated **GitHub App** for authentication instead of the default built-in token.

## Why

We need to add an org-level exclusion to the branch ruleset so our automation can continue pushing commits and opening pull requests. The built-in token can't be added to org-level exclusion lists — only GitHub Apps can.

## What you need to do before merging

1. **Create a GitHub App** in the org with these permissions: Issues (read/write), Contents (read/write), Pull Requests (read/write)
2. **Install the app** on this repository
3. **Add two repository secrets:**
   - `APP_ID` — the numeric ID shown on the app's settings page
   - `APP_PRIVATE_KEY` — the PEM private key downloaded when creating the app
4. **Add the app as a bypass** in the org-level ruleset

Once the secrets are in place and the bypass is configured, all workflows will work exactly as before — just authenticated as the app instead of the default token.