### PR TITLE
Fix/double evaluation result

### DIFF
--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -2,15 +2,16 @@ name: Evaluate Submission
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   evaluate:
-    # Run when a submission issue is opened with the label already applied,
-    # OR when the 'submission' label is added to an existing issue.
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'submission') ||
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'submission'))
+    # Run when the 'submission' label is added — covers both issue templates
+    # (which apply the label at creation, firing a 'labeled' event) and
+    # manual label additions by admins. Using only 'labeled' avoids the
+    # double-run caused by GitHub firing both 'opened' and 'labeled' when
+    # an issue template pre-applies a label.
+    if: github.event.action == 'labeled' && github.event.label.name == 'submission'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -18,13 +19,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Skip multi-URL submissions (handled by split-submission workflow)
         id: guard
         env:
@@ -41,8 +35,6 @@ jobs:
       - name: Checkout
         if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         if: steps.guard.outputs.skip != 'true'
@@ -62,7 +54,7 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           python scripts/check_duplicates.py
@@ -92,7 +84,6 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const results = fs.readFileSync('evaluation_results.md', 'utf8');
@@ -108,7 +99,6 @@ jobs:
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const score = parseInt(fs.readFileSync('evaluation_score.txt', 'utf8').trim());
@@ -150,7 +140,7 @@ jobs:
       - name: Create PR if score >= 2
         if: steps.guard.outputs.skip != 'true' && steps.check_duplicate.outputs.is_duplicate != 'true' && fromJSON(steps.read_outputs.outputs.score) >= 2 && steps.read_outputs.outputs.has_data == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           python scripts/create_submission_pr.py

--- a/.github/workflows/split-submission.yml
+++ b/.github/workflows/split-submission.yml
@@ -2,16 +2,14 @@ name: Split Multi-URL Submission
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 jobs:
   split:
     # Only run on submission issues that contain more than one real URL.
-    # Triggers when opened with the label already applied, or when the label
-    # is added later (e.g. by an admin to a manually-created issue).
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'submission') ||
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'submission'))
+    # 'labeled' covers both template-applied labels (fires at creation) and
+    # manual label additions — removing 'opened' eliminates the double-run.
+    if: github.event.action == 'labeled' && github.event.label.name == 'submission'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -19,13 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Count submitted URLs
         id: url-count
         env:
@@ -45,8 +36,6 @@ jobs:
       - name: Checkout
         if: steps.url-count.outputs.is_multi == 'true'
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         if: steps.url-count.outputs.is_multi == 'true'
@@ -64,6 +53,6 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python scripts/split_submission.py


### PR DESCRIPTION
The root cause is a GitHub behavior with issue templates: when a submission is opened with the submission label pre-applied by the template, GitHub fires both events simultaneously:

1. opened → condition opened + has submission label ✅ → workflow runs
2. labeled → condition labeled + label name is submission ✅ → workflow runs again

The opened condition was written to catch label-at-creation, but GitHub's labeled event also fires for labels applied during creation — so both conditions are always true at the same time for every normal submission.

The fix: drop opened from the trigger entirely. labeled alone covers both cases — template-applied labels and manually-added labels.