### PR TITLE
fix: duplicate check against README only; auto-label mobile submissions

### DIFF
--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -2,9 +2,10 @@
 """
 Duplicate detection for awesome-alt-clouds submissions.
 
-Reads submission info from environment variables, checks clouds.json and
-GitHub Issues for duplicates, posts a comment + label + optionally closes
-the issue, then writes is_duplicate=true/false to $GITHUB_OUTPUT.
+Reads submission info from environment variables, checks clouds.json
+(the authoritative list from README.md) for duplicates, posts a comment
++ label + optionally closes the issue, then writes is_duplicate=true/false
+to $GITHUB_OUTPUT.
 
 Exits 0 always — failures are non-fatal to avoid blocking submissions.
 """
@@ -99,66 +100,6 @@ def check_clouds_json(
     return (None, None)
 
 
-def check_github_issues(
-    submitted_domain: str,
-    gh_token: str,
-    repo: str,
-    current_issue_number: int,
-    max_issues: int = 500,
-) -> tuple[str | None, dict | None]:
-    """Check submitted domain against all GitHub Issues with label 'submission'.
-
-    Paginates up to max_issues. Skips the current issue.
-
-    Returns:
-        ('existing_issue', issue) — domain matches an existing issue's URL
-        (None, None)              — no match or API error
-    """
-    headers = {
-        'Authorization': f'Bearer {gh_token}',
-        'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-    }
-    url: str | None = f'https://api.github.com/repos/{repo}/issues'
-    params = {'labels': 'submission', 'state': 'all', 'per_page': 100}
-
-    fetched = 0
-    try:
-        while url and fetched < max_issues:
-            resp = requests.get(url, headers=headers, params=params, timeout=15)
-            resp.raise_for_status()
-            issues = resp.json()
-            fetched += len(issues)
-
-            for issue in issues:
-                if issue.get('number') == current_issue_number:
-                    continue
-                body = issue.get('body') or ''
-                # Extract URLs from the issue body
-                urls_in_body = re.findall(r'https?://[^\s\)]+', body)
-                for raw_url in urls_in_body:
-                    if normalize_domain(raw_url) == submitted_domain:
-                        return ('existing_issue', issue)
-
-            # Follow pagination via Link header
-            link = resp.headers.get('Link', '')
-            next_url = None
-            for part in link.split(','):
-                if 'rel="next"' in part:
-                    match = re.search(r'<([^>]+)>', part)
-                    if match:
-                        next_url = match.group(1)
-                        break
-            url = next_url
-            params = {}  # params already encoded in next_url
-
-    except Exception as e:
-        logging.warning('GitHub Issues API check failed: %s', e)
-        return (None, None)
-
-    return (None, None)
-
-
 def _gh_headers(gh_token: str) -> dict:
     return {
         'Authorization': f'Bearer {gh_token}',
@@ -197,48 +138,34 @@ def close_issue(repo: str, issue_number: int, gh_token: str) -> None:
         logging.warning('Failed to close issue %s: %s', issue_number, e)
 
 
-def build_comment(match_type: str, match: dict, source: str) -> str:
+def build_comment(match_type: str, match: dict) -> str:
     """Build a GitHub comment body for a duplicate match.
 
     Args:
-        match_type: 'exact_domain', 'fuzzy_name', or 'existing_issue'
-        match:      the matching entry dict (from clouds.json or GitHub Issues)
-        source:     'clouds_json' or 'github_issues'
+        match_type: 'exact_domain' or 'fuzzy_name'
+        match:      the matching entry dict from clouds.json
     """
-    if match_type in ('exact_domain', 'existing_issue'):
-        if source == 'clouds_json':
-            name = match.get('name', 'Unknown')
-            url = match.get('url', '')
-            desc = match.get('description', '')
-            return (
-                '⚠️ **Duplicate Submission**\n\n'
-                'This service is already included in the Awesome Alt Clouds list:\n'
-                f'- **[{name}]({url})** — {desc}\n\n'
-                'Closing this issue as a duplicate. If you believe this is a different '
-                'service or a significant update, please reopen with additional context.'
-            )
-        else:  # github_issues
-            issue_url = match.get('html_url', '')
-            issue_title = match.get('title', 'existing issue')
-            return (
-                '⚠️ **Duplicate Submission**\n\n'
-                'This service has already been submitted:\n'
-                f'- **[{issue_title}]({issue_url})**\n\n'
-                'Closing this issue as a duplicate. If you believe this is a different '
-                'service or a significant update, please reopen with additional context.'
-            )
-    else:
-        if match_type != 'fuzzy_name':
-            raise ValueError(f'Unknown match_type: {match_type!r}')
-        name = match.get('name', 'Unknown')
-        url = match.get('url', '')
-        desc = match.get('description', '')
+    name = match.get('name', 'Unknown')
+    url = match.get('url', '')
+    desc = match.get('description', '')
+
+    if match_type == 'exact_domain':
+        return (
+            '⚠️ **Duplicate Submission**\n\n'
+            'This service is already included in the Awesome Alt Clouds list:\n'
+            f'- **[{name}]({url})** — {desc}\n\n'
+            'Closing this issue as a duplicate. If you believe this is a different '
+            'service or a significant update, please reopen with additional context.'
+        )
+    elif match_type == 'fuzzy_name':
         return (
             '⚠️ **Possible Duplicate**\n\n'
             'A similar service may already be listed:\n'
             f'- **[{name}]({url})** — {desc}\n\n'
             'Proceeding with admin review, but flagging as a possible duplicate.'
         )
+    else:
+        raise ValueError(f'Unknown match_type: {match_type!r}')
 
 
 # Path to clouds.json — overridable in tests
@@ -284,7 +211,9 @@ def main() -> None:
     submitted_domain = normalize_domain(urls[0])
     submitted_name = issue_title
 
-    # --- Check clouds.json ---
+    # Check clouds.json — the authoritative list derived from README.md.
+    # GitHub Issues are intentionally NOT checked: a previously-rejected submission
+    # should not block a valid resubmission.
     clouds: list[dict] = []
     try:
         with open(_CLOUDS_JSON_PATH, 'r', encoding='utf-8') as f:
@@ -294,18 +223,12 @@ def main() -> None:
 
     match_type, match = check_clouds_json(submitted_domain, submitted_name, clouds)
 
-    if match_type is None and gh_token and repo:
-        match_type, match = check_github_issues(
-            submitted_domain, gh_token, repo, current_issue_number=issue_number
-        )
-
     if match_type is not None:
         assert match is not None, f"match_type is {match_type!r} but match is None"
-        source = 'clouds_json' if match in clouds else 'github_issues'
-        comment = build_comment(match_type, match, source=source)
+        comment = build_comment(match_type, match)
         post_comment(repo, issue_number, comment, gh_token)
         add_label(repo, issue_number, 'duplicate', gh_token)
-        if match_type in ('exact_domain', 'existing_issue'):
+        if match_type == 'exact_domain':
             close_issue(repo, issue_number, gh_token)
         _write_github_output('is_duplicate', 'true')
         _write_github_output('duplicate_reason', match_type)

--- a/tests/test_check_duplicates.py
+++ b/tests/test_check_duplicates.py
@@ -1,7 +1,7 @@
 # tests/test_check_duplicates.py
 import sys
 import os
-import json  # used by TestMain (added in a later task)
+import json
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 
 import pytest
@@ -151,12 +151,12 @@ class TestCheckCloudsJson:
 
 
 # ---------------------------------------------------------------------------
-# check_github_issues
+# post_comment / add_label / close_issue
 # ---------------------------------------------------------------------------
 
 
 def _make_gh_response(issues, link_header=None):
-    """Build a mock requests.Response for the GitHub Issues API."""
+    """Build a mock requests.Response for the GitHub API."""
     mock = MagicMock()
     mock.status_code = 200
     mock.json.return_value = issues
@@ -165,104 +165,6 @@ def _make_gh_response(issues, link_header=None):
         mock.headers['Link'] = link_header
     mock.raise_for_status = MagicMock()
     return mock
-
-
-class TestCheckGithubIssues:
-
-    ISSUES = [
-        {
-            "number": 10,
-            "title": "Add Fly.io",
-            "body": "**URL:** https://fly.io\n**Name:** Fly.io",
-            "html_url": "https://github.com/owner/repo/issues/10",
-        },
-        {
-            "number": 11,
-            "title": "Add ZeroTier",
-            "body": "**URL:** https://www.zerotier.com\n**Name:** ZeroTier",
-            "html_url": "https://github.com/owner/repo/issues/11",
-        },
-        {
-            "number": 99,
-            "title": "Add something else",
-            "body": "no url here",
-            "html_url": "https://github.com/owner/repo/issues/99",
-        },
-    ]
-
-    def test_exact_domain_match_in_issues(self):
-        with patch('requests.get', return_value=_make_gh_response(self.ISSUES)):
-            match_type, issue = cd.check_github_issues(
-                'fly.io', 'token', 'owner/repo', current_issue_number=200
-            )
-        assert match_type == 'existing_issue'
-        assert issue['number'] == 10
-
-    def test_skips_current_issue(self):
-        # If the current issue number matches, it should NOT be returned as a duplicate
-        issues = [
-            {
-                "number": 200,
-                "title": "Add Fly.io",
-                "body": "**URL:** https://fly.io",
-                "html_url": "https://github.com/owner/repo/issues/200",
-            }
-        ]
-        with patch('requests.get', return_value=_make_gh_response(issues)):
-            result = cd.check_github_issues(
-                'fly.io', 'token', 'owner/repo', current_issue_number=200
-            )
-        assert result == (None, None)
-
-    def test_no_match_returns_none_tuple(self):
-        with patch('requests.get', return_value=_make_gh_response(self.ISSUES)):
-            result = cd.check_github_issues(
-                'brandnew.io', 'token', 'owner/repo', current_issue_number=999
-            )
-        assert result == (None, None)
-
-    def test_api_failure_returns_none_tuple(self):
-        with patch('requests.get', side_effect=Exception('network error')):
-            result = cd.check_github_issues(
-                'fly.io', 'token', 'owner/repo', current_issue_number=999
-            )
-        assert result == (None, None)
-
-    def test_paginates_when_link_header_present(self):
-        page1 = [
-            {
-                "number": 10,
-                "title": "Add Something",
-                "body": "**URL:** https://page1only.io",
-                "html_url": "https://github.com/owner/repo/issues/10",
-            }
-        ]
-        page2 = [
-            {
-                "number": 20,
-                "title": "Add Fly.io",
-                "body": "**URL:** https://fly.io",
-                "html_url": "https://github.com/owner/repo/issues/20",
-            }
-        ]
-        link_header = '<https://api.github.com/repos/owner/repo/issues?page=2>; rel="next"'
-
-        responses = [
-            _make_gh_response(page1, link_header=link_header),
-            _make_gh_response(page2),  # no next link → stop
-        ]
-
-        with patch('requests.get', side_effect=responses):
-            match_type, issue = cd.check_github_issues(
-                'fly.io', 'token', 'owner/repo', current_issue_number=999
-            )
-        assert match_type == 'existing_issue'
-        assert issue['number'] == 20
-
-
-# ---------------------------------------------------------------------------
-# post_comment / add_label / close_issue
-# ---------------------------------------------------------------------------
 
 class TestGitHubApiActions:
 
@@ -326,38 +228,27 @@ class TestBuildComment:
         'description': 'App hosting with global anycast networking.',
     }
 
-    ISSUE = {
-        'number': 10,
-        'title': 'Add Fly.io',
-        'html_url': 'https://github.com/owner/repo/issues/10',
-        'body': '**URL:** https://fly.io',
-    }
-
-    def test_exact_domain_clouds_json_comment_mentions_name(self):
-        comment = cd.build_comment('exact_domain', self.ENTRY, source='clouds_json')
+    def test_exact_domain_comment_mentions_name(self):
+        comment = cd.build_comment('exact_domain', self.ENTRY)
         assert 'Fly.io' in comment
         assert 'https://fly.io' in comment
         assert 'App hosting' in comment
 
-    def test_exact_domain_clouds_json_comment_contains_closing_text(self):
-        comment = cd.build_comment('exact_domain', self.ENTRY, source='clouds_json')
+    def test_exact_domain_comment_contains_closing_text(self):
+        comment = cd.build_comment('exact_domain', self.ENTRY)
         assert 'Closing' in comment or 'closing' in comment
 
     def test_fuzzy_name_comment_says_possible_duplicate(self):
-        comment = cd.build_comment('fuzzy_name', self.ENTRY, source='clouds_json')
+        comment = cd.build_comment('fuzzy_name', self.ENTRY)
         assert 'Possible Duplicate' in comment or 'possible duplicate' in comment.lower()
 
     def test_fuzzy_name_comment_does_not_mention_closing(self):
-        comment = cd.build_comment('fuzzy_name', self.ENTRY, source='clouds_json')
+        comment = cd.build_comment('fuzzy_name', self.ENTRY)
         assert 'Closing' not in comment
 
-    def test_existing_issue_comment_links_to_issue(self):
-        comment = cd.build_comment('existing_issue', self.ISSUE, source='github_issues')
-        assert 'https://github.com/owner/repo/issues/10' in comment
-
-    def test_existing_issue_comment_contains_closing_text(self):
-        comment = cd.build_comment('existing_issue', self.ISSUE, source='github_issues')
-        assert 'Closing' in comment or 'closing' in comment
+    def test_unknown_match_type_raises(self):
+        with pytest.raises(ValueError):
+            cd.build_comment('unknown_type', self.ENTRY)
 
 
 # ---------------------------------------------------------------------------
@@ -379,8 +270,8 @@ class TestMain:
         }
     ]
 
-    def _run_main(self, env, clouds_json_content=None, issues_response=None):
-        """Helper: run main() with patched env, clouds.json, and GitHub API."""
+    def _run_main(self, env, clouds_json_content=None):
+        """Helper: run main() with patched env and clouds.json."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump(clouds_json_content or self.CLOUDS, f)
             clouds_path = f.name
@@ -398,12 +289,7 @@ class TestMain:
                     with patch.object(cd, 'post_comment', no_op):
                         with patch.object(cd, 'add_label', no_op):
                             with patch.object(cd, 'close_issue', no_op):
-                                if issues_response is not None:
-                                    with patch('requests.get', return_value=issues_response):
-                                        cd.main()
-                                else:
-                                    with patch('requests.get', return_value=_make_gh_response([])):
-                                        cd.main()
+                                cd.main()
 
         os.unlink(clouds_path)
         return output_lines, no_op
@@ -437,8 +323,7 @@ class TestMain:
                     with patch.object(cd, 'post_comment', MagicMock()):
                         with patch.object(cd, 'add_label', MagicMock()):
                             with patch.object(cd, 'close_issue', close_mock):
-                                with patch('requests.get', return_value=_make_gh_response([])):
-                                    cd.main()
+                                cd.main()
         os.unlink(clouds_path)
         close_mock.assert_called_once()
 
@@ -482,8 +367,7 @@ class TestMain:
                     with patch.object(cd, 'post_comment', MagicMock()):
                         with patch.object(cd, 'add_label', MagicMock()):
                             with patch.object(cd, 'close_issue', close_mock):
-                                with patch('requests.get', return_value=_make_gh_response([])):
-                                    cd.main()
+                                cd.main()
         os.unlink(clouds_path)
         close_mock.assert_not_called()
 
@@ -499,6 +383,5 @@ class TestMain:
         with patch.dict(os.environ, env, clear=True):
             with patch.object(cd, '_CLOUDS_JSON_PATH', '/nonexistent/path/clouds.json'):
                 with patch.object(cd, '_write_github_output', side_effect=lambda k, v: output_lines.append(f'{k}={v}')):
-                    with patch('requests.get', return_value=_make_gh_response([])):
-                        cd.main()
+                    cd.main()
         assert any('is_duplicate=false' in line for line in output_lines)


### PR DESCRIPTION
- Remove check_github_issues: previously-rejected issues were blocking valid resubmissions since state=all was used. Duplicate detection now checks only clouds.json (the authoritative list from README.md).
- Add auto-label-submission workflow: fires on issues:opened and applies the 'submission' label when the title starts with '[Submission]', fixing mobile submissions where the GitHub app drops URL params (including &labels=submission) after its template-chooser screen.