### PR TITLE
fix: mobile submission flow (tap bug + auto-label by body)

### DIFF
--- a/.github/workflows/auto-label-submission.yml
+++ b/.github/workflows/auto-label-submission.yml
@@ -1,9 +1,10 @@
 name: Auto-label Submissions
 
-# Safety net for mobile: the GitHub app drops URL params (including
-# &labels=submission) when it shows the template-chooser screen.
-# This workflow catches any issue opened without the label and adds it,
-# which then triggers the evaluate-submission and split-submission workflows.
+# Safety net for mobile: the GitHub app drops ALL URL params (title, body,
+# labels) when it shows a blank new-issue screen. The user pastes the body
+# from clipboard but types a free-form title, so title-pattern matching is
+# unreliable. Instead we match on a unique footer the form always injects
+# into the body, which survives the paste step intact.
 
 on:
   issues:
@@ -11,9 +12,10 @@ on:
 
 jobs:
   label:
-    # Only act on issues whose title matches the form's pattern.
-    # The submit page always sets "[Submission] <domain>" as the title.
-    if: startsWith(github.event.issue.title, '[Submission]')
+    # The submit form always appends this sentence to the issue body.
+    # Matching on body content is the only reliable signal when the title
+    # is typed freely by the user on mobile.
+    if: contains(github.event.issue.body, 'automatically created via the submission form')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/docs/index.html
+++ b/docs/index.html
@@ -404,6 +404,8 @@
       gap: 0.5rem;
       margin-bottom: 0.75rem;
       text-decoration: none;
+      touch-action: manipulation;
+      -webkit-tap-highlight-color: transparent;
     }
 
     .contribute-btn:hover {
@@ -1176,6 +1178,8 @@
       .search-input,
       .sorter-select {
         font-size: 1rem;
+      }
+
       .top-bar .search-box {
         display: none;
       }
@@ -1650,14 +1654,14 @@
     function openDrawer() {
       document.getElementById('mobileDrawer').classList.add('active');
       document.getElementById('drawerOverlay').classList.add('active');
-      document.body.style.overflow = 'hidden';
+      document.documentElement.style.overflow = 'hidden';
     }
 
     function closeDrawer() {
       document.getElementById('mobileDrawer').classList.remove('active');
       document.getElementById('drawerOverlay').classList.remove('active');
       if (!document.querySelector('.modal-overlay.active')) {
-        document.body.style.overflow = '';
+        document.documentElement.style.overflow = '';
       }
     }
 
@@ -1677,7 +1681,7 @@
           history.pushState({}, '', location.pathname + location.search);
         }
         closeDrawer();
-        document.body.style.overflow = '';
+        document.documentElement.style.overflow = '';
       }
     });
 


### PR DESCRIPTION
## Summary

Two independent mobile bugs fixed in this PR, both affecting the submission flow on iOS.

### 1. Submit button required ~10 taps to navigate (`docs/index.html`)

Three compounding issues:

- **Root cause**: `openDrawer()` set `document.body.style.overflow = 'hidden'`. iOS Safari blocks touch events on `position:fixed` children (the drawer) when `overflow:hidden` is on `<body>`. Changed to `document.documentElement` (the `<html>` element), which iOS handles correctly.
- `touch-action: manipulation` was missing on `.contribute-btn` — iOS added a 300ms tap delay waiting for double-tap-to-zoom. Added `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent`.
- Missing CSS closing brace on `.search-input, .sorter-select` was swallowing `.top-bar .search-box { display: none }` inside the mobile media query, leaving the desktop search box visible on mobile.

### 2. Auto-label matched on title, not body (`.github/workflows/auto-label-submission.yml`)

The previous fix used `startsWith(github.event.issue.title, '[Submission]')` to detect form submissions. But the GitHub app drops **all** URL params (including the pre-filled title) when opening a new issue on mobile — so the user types a free-form title and the pattern never matched (see #214).

Changed to match on body content instead:
```
contains(github.event.issue.body, 'automatically created via the submission form')
```
This string is always present in the pasted body, regardless of what title the user types.

## Test plan

- [ ] On iOS, open the drawer via the burger menu and tap "Add a Cloud" — should navigate to `/submit` on first tap
- [ ] Submit via alt-clouds.org/submit on mobile → open GitHub app → type any title → paste body → submit issue → issue should receive `submission` label automatically without manual intervention