### PR TITLE
fix: trigger evaluate-submission on opened for unlabeled form issues

### DIFF
--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -2,16 +2,25 @@ name: Evaluate Submission
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 jobs:
   evaluate:
-    # Run when the 'submission' label is added — covers both issue templates
-    # (which apply the label at creation, firing a 'labeled' event) and
-    # manual label additions by admins. Using only 'labeled' avoids the
-    # double-run caused by GitHub firing both 'opened' and 'labeled' when
-    # an issue template pre-applies a label.
-    if: github.event.action == 'labeled' && github.event.label.name == 'submission'
+    # Trigger conditions:
+    # 1. 'labeled' with 'submission' — covers issue templates that pre-apply the
+    #    label (GitHub fires a user-context 'labeled' event) and manual additions.
+    # 2. 'opened' without the 'submission' label already present — covers mobile /
+    #    API submissions where the label is absent at creation and is later added
+    #    by the auto-label workflow via GITHUB_TOKEN. GitHub suppresses workflow
+    #    triggers for GITHUB_TOKEN-generated label events, so we catch these on
+    #    'opened' instead. The body-text guard ensures we only act on real
+    #    submission-form issues. Guarding on label absence prevents a double-run
+    #    when an issue template pre-applies the label (that path uses condition 1).
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'submission') ||
+      (github.event.action == 'opened' &&
+       contains(github.event.issue.body, 'automatically created via the submission form') &&
+       !contains(github.event.issue.labels.*.name, 'submission'))
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- Fixes issue #218 where `evaluate-submission` never ran for a form submission
- Root cause: when `auto-label-submission` adds the `submission` label via `GITHUB_TOKEN`, GitHub suppresses the resulting `labeled` event so no other workflow fires
- Fix: add `opened` as a second trigger on `evaluate-submission`, guarded so it only runs for real submission-form issues that don't already have the `submission` label

## Root Cause Detail

GitHub deliberately does not fire workflow triggers for `labeled` events generated by `GITHUB_TOKEN` (to prevent infinite loops). The `auto-label-submission` workflow adds the label on `opened` issues that lack it (mobile/API path). This silently drops the evaluate step.

The two trigger conditions now cover both submission paths without double-running:

| Path | `opened` condition | `labeled` condition |
|---|---|---|
| Template (label pre-applied) | skips (label already present) | fires ✓ |
| Mobile/API (no label at creation) | fires ✓ | suppressed by GitHub (no double-run) |

## Test plan

- [ ] Verify `evaluate-submission` runs on a new mobile-style submission (body contains footer, no pre-applied label)
- [ ] Verify `evaluate-submission` does NOT double-run on a template submission (label pre-applied at creation)
- [ ] Verify issue #218 can be manually re-triggered or a similar submission now evaluates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)