### PR TITLE
feat: add watchlist for multi-submitted candidates (#163)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'README.md'
+      - 'WATCHLIST.md'
       - 'docs/**'
   workflow_dispatch:
 
@@ -40,16 +41,20 @@ jobs:
         run: |
           python scripts/generate_llms.py docs/clouds.json docs/
 
+      - name: Generate watchlist.json from WATCHLIST.md
+        run: |
+          python scripts/generate_watchlist_json.py
+
       - name: Commit updated files
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/clouds.json docs/llms.txt docs/llms-full.txt
+          git add docs/clouds.json docs/llms.txt docs/llms-full.txt docs/watchlist.json
 
           # Only commit if there are changes
           if ! git diff --staged --quiet; then
             git commit -m "Auto-update clouds.json from README [skip ci]"
             git push
           else
-            echo "No changes to clouds.json, llms.txt, or llms-full.txt"
+            echo "No changes to generated docs files"
           fi

--- a/.github/workflows/watchlist.yml
+++ b/.github/workflows/watchlist.yml
@@ -1,0 +1,113 @@
+name: Watchlist
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add-to-watchlist:
+    # Trigger: admin comments /watchlist on a submission issue
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'submission') &&
+      startsWith(github.event.comment.body, '/watchlist')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check permissions
+        id: check-permission
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['admin', 'maintain', 'write'].includes(perm.permission);
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} You don't have permission to add entries to the watchlist.`,
+              });
+            }
+            core.setOutput('allowed', String(allowed));
+
+      - name: Checkout
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: steps.check-permission.outputs.allowed == 'true'
+        run: pip install requests
+
+      - name: Add to watchlist
+        if: steps.check-permission.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: python scripts/watchlist_add.py
+
+      - name: Regenerate watchlist.json
+        if: steps.check-permission.outputs.allowed == 'true'
+        run: python scripts/generate_watchlist_json.py
+
+      - name: Commit and push
+        if: steps.check-permission.outputs.allowed == 'true'
+        run: |
+          changed=$(cat /tmp/watchlist_changed.txt 2>/dev/null || echo "false")
+          if [ "$changed" = "true" ]; then
+            name=$(cat /tmp/watchlist_name.txt 2>/dev/null || echo "entry")
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add WATCHLIST.md docs/watchlist.json
+            git commit -m "chore: add ${name} to watchlist [skip ci]"
+            git push
+          else
+            echo "No changes to commit."
+          fi
+
+      - name: Comment result
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const changed = fs.readFileSync('/tmp/watchlist_changed.txt', 'utf8').trim();
+            const name = fs.existsSync('/tmp/watchlist_name.txt')
+              ? fs.readFileSync('/tmp/watchlist_name.txt', 'utf8').trim()
+              : 'This service';
+
+            const body = changed === 'true'
+              ? `📋 **Added to Watchlist**\n\n${name} has been added to [WATCHLIST.md](../blob/main/WATCHLIST.md). It will be re-evaluated once the criteria listed in the evaluation results above have been addressed.`
+              : `ℹ️ **Already on Watchlist**\n\n${name} is already tracked in [WATCHLIST.md](../blob/main/WATCHLIST.md).`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,16 @@ We welcome additions, corrections, and improvements to this list of alternative 
 3. Make your changes to `README.md`
 4. Submit a pull request and briefly explain your additions
 
-💬 For questions or suggestions, feel free to [open an issue](https://github.com/yourusername/awesome-alt-clouds/issues).
+## Borderline Submissions
+
+If your submission doesn't meet all three criteria yet, it may be added to the [Watchlist](WATCHLIST.md) instead of being rejected outright. The watchlist tracks promising candidates with a clear path to qualification.
+
+A submission lands on the watchlist when:
+- It scores 1/3 on the automated evaluation, **and**
+- A maintainer judges it worth tracking (e.g. the service is actively improving or is widely referenced in the community).
+
+Check the watchlist before re-submitting — your service may already be tracked there. To trigger a re-evaluation, comment on your original submission issue with evidence that the missing criteria are now met, or open a new submission.
+
+💬 For questions or suggestions, feel free to [open an issue](https://github.com/datum-cloud/awesome-alt-clouds/issues).
 
 Thank you!

--- a/README.md
+++ b/README.md
@@ -595,3 +595,5 @@ Why track these? The cloud landscape changes fast. Today's "contact sales only" 
 ## Contributing
 
 Pull requests welcome! Please ensure that submissions meet the Alt Cloud [contributing guide](CONTRIBUTING.md) and are categorized accurately.
+
+Submissions that don't yet meet the criteria may be tracked in the [Watchlist](WATCHLIST.md) — a structured list of candidates with a clear path to qualification.

--- a/WATCHLIST.md
+++ b/WATCHLIST.md
@@ -1,0 +1,36 @@
+# Watchlist
+
+Candidates submitted to Awesome Alt Clouds that don't yet meet inclusion criteria. This list provides a transparent path forward for promising services and prevents the same submissions from being re-litigated from scratch.
+
+Only companies submitted **two or more times** with continued community interest are tracked here — a signal that the service is worth watching even though it hasn't qualified yet.
+
+## How It Works
+
+**Submitters** — If your service appears here, the "Criteria Needed" column shows exactly what must change before it qualifies. Address those gaps and re-submit (or comment on your original submission issue with evidence of the change).
+
+**Community** — If you have evidence that a listed candidate now meets its missing criteria, comment on the original submission issue.
+
+**Maintainers** — Add entries by commenting `/watchlist` on any submission issue. Review the list quarterly and update "Last Reviewed" dates.
+
+## Promotion Rules
+
+A watchlist entry moves to the main list when:
+1. It scores **2/3 or higher** on a fresh evaluation — open a new submission or comment on the original issue with evidence of the criteria change.
+2. A maintainer manually approves it with `/approve` on a submission issue.
+
+## Removal Rules
+
+An entry is removed when:
+- It is **promoted** to the main list.
+- It shows **no progress for 6 months** — the missing criteria remain unmet with no evidence of change.
+- The service **shuts down** or becomes publicly inaccessible.
+
+## Review Cadence
+
+Maintainers review the watchlist **quarterly** (January, April, July, October). The reviewing maintainer updates the "Last Reviewed" date for each active entry and removes or promotes stale ones.
+
+## Entries
+
+| Name | URL | Likely Category | Date Added | Reason Not Qualifying | Criteria Needed | Last Reviewed |
+|------|-----|-----------------|------------|-----------------------|-----------------|---------------|
+| Iren | https://iren.com | GPU & AI Compute Clouds | 2026-03-18 | Score 1/3: no transparent pricing, no self-service signup | Public pricing page; self-service signup | 2026-05-21 |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1249,6 +1249,12 @@
         <span>+</span>
         <span>Submit a Cloud</span>
       </a>
+      <a href="watchlist.html" class="page-link">
+        <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+        </svg>
+        <span>Watchlist</span>
+      </a>
       <button class="page-link" onclick="openModal('extensionModal'); closeDrawer()">
         <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"></path>
@@ -1316,6 +1322,12 @@
         </a>
 
         <div class="page-links">
+          <a href="watchlist.html" class="page-link">
+            <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+            </svg>
+            <span>Watchlist</span>
+          </a>
           <button class="page-link" onclick="openModal('extensionModal')">
             <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5"></path>

--- a/docs/watchlist.html
+++ b/docs/watchlist.html
@@ -1,0 +1,578 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Watchlist | Awesome Alt Clouds</title>
+  <meta name="description" content="Candidates submitted to Awesome Alt Clouds that don't yet meet inclusion criteria — tracked here with a clear path to qualification.">
+  <link rel="canonical" href="https://www.alt-clouds.org/watchlist.html">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/datum-cloud/awesome-alt-clouds/main/altclouds-logo.png">
+  <script src="https://cdn.usefathom.com/script.js" data-site="ZQEMDUAQ" defer></script>
+  <style>
+    :root {
+      --warm-stone: #78716C;
+      --soft-sage: #A3B18A;
+      --clay-beige: #E9DCC9;
+      --rich-earth: #3E362E;
+      --bright-tangerine: #FF6B35;
+      --cream: #FAF7F0;
+      --charcoal: #2D2D2A;
+      --bg-primary: var(--cream);
+      --bg-card: #ffffff;
+      --text-primary: var(--rich-earth);
+      --text-secondary: var(--warm-stone);
+      --border: var(--clay-beige);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'IBM Plex Sans', -apple-system, system-ui, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    /* ── Layout ── */
+    .layout {
+      display: flex;
+      min-height: 100vh;
+    }
+
+    /* ── Sidebar ── */
+    .sidebar {
+      width: 280px;
+      background: var(--cream);
+      border-right: 1px solid var(--border);
+      padding: 1.5rem 1rem;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      flex-shrink: 0;
+    }
+
+    .logo-section {
+      margin-bottom: 1.5rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+      text-decoration: none;
+    }
+
+    .logo-img { width: 40px; height: 40px; border-radius: 8px; }
+
+    .logo-text h1 {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+    }
+
+    .tagline {
+      font-size: 0.8125rem;
+      color: var(--bright-tangerine);
+      font-weight: 500;
+      margin-bottom: 0.25rem;
+    }
+
+    .sidebar-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 8px;
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      text-decoration: none;
+      transition: all 0.2s;
+      border: 1px solid transparent;
+    }
+
+    .nav-item:hover { background: var(--clay-beige); color: var(--text-primary); }
+
+    .nav-item.active {
+      background: var(--rich-earth);
+      color: var(--cream);
+      font-weight: 500;
+    }
+
+    .sidebar-bottom {
+      margin-top: auto;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .contribute-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      width: 100%;
+      padding: 0.625rem;
+      background: var(--bright-tangerine);
+      border: none;
+      border-radius: 8px;
+      color: white;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.2s;
+      font-family: 'IBM Plex Sans', sans-serif;
+    }
+
+    .contribute-btn:hover { background: #e55a25; transform: translateY(-1px); }
+
+    /* ── Main content ── */
+    .main-content {
+      flex: 1;
+      padding: 2rem;
+      max-width: 960px;
+    }
+
+    .page-header {
+      margin-bottom: 2rem;
+    }
+
+    .page-title {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 2rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+      margin-bottom: 0.5rem;
+    }
+
+    .page-subtitle {
+      font-size: 0.9375rem;
+      color: var(--text-secondary);
+      max-width: 600px;
+      line-height: 1.7;
+    }
+
+    /* ── Info strip ── */
+    .info-strip {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+
+    .info-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+    }
+
+    .info-card-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--warm-stone);
+      margin-bottom: 0.375rem;
+    }
+
+    .info-card-value {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+    }
+
+    /* ── Watchlist cards ── */
+    .cards-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .watch-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.875rem;
+      transition: box-shadow 0.2s, transform 0.2s;
+    }
+
+    .watch-card:hover {
+      box-shadow: 0 4px 16px rgba(62, 54, 46, 0.1);
+      transform: translateY(-2px);
+    }
+
+    .watch-card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .watch-logo {
+      width: 40px;
+      height: 40px;
+      border-radius: 8px;
+      background: var(--clay-beige);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+      flex-shrink: 0;
+      overflow: hidden;
+    }
+
+    .watch-logo img { width: 100%; height: 100%; object-fit: contain; }
+
+    .watch-name {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+    }
+
+    .watch-category {
+      font-size: 0.75rem;
+      color: var(--warm-stone);
+      margin-top: 0.125rem;
+    }
+
+    .watch-reason {
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      background: #fff8f5;
+      border: 1px solid #fde8dc;
+      border-radius: 8px;
+      padding: 0.75rem;
+      line-height: 1.5;
+    }
+
+    .watch-reason-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--bright-tangerine);
+      margin-bottom: 0.25rem;
+    }
+
+    .watch-criteria {
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      background: #f5faf0;
+      border: 1px solid #d8eacc;
+      border-radius: 8px;
+      padding: 0.75rem;
+      line-height: 1.5;
+    }
+
+    .watch-criteria-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--soft-sage);
+      margin-bottom: 0.25rem;
+    }
+
+    .watch-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding-top: 0.75rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .watch-meta {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.6875rem;
+      color: var(--warm-stone);
+    }
+
+    .watch-url {
+      color: var(--bright-tangerine);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      transition: gap 0.2s;
+    }
+
+    .watch-url:hover { gap: 0.625rem; text-decoration: underline; }
+
+    /* ── Empty state ── */
+    .empty-state {
+      text-align: center;
+      padding: 4rem 2rem;
+      color: var(--text-secondary);
+    }
+
+    .empty-icon { font-size: 3rem; margin-bottom: 1rem; opacity: 0.4; }
+
+    /* ── Rules section ── */
+    .rules-section {
+      margin-top: 2.5rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .rules-title {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--rich-earth);
+      margin-bottom: 1rem;
+    }
+
+    .rules-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+
+    .rule-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+    }
+
+    .rule-card-title {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 0.375rem;
+    }
+
+    .rule-card-body {
+      font-size: 0.8125rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    /* ── Mobile ── */
+    @media (max-width: 768px) {
+      .sidebar { display: none; }
+      .main-content { padding: 1.25rem; }
+      .cards-grid { grid-template-columns: 1fr; }
+      .page-title { font-size: 1.5rem; }
+      .mobile-back {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        color: var(--bright-tangerine);
+        text-decoration: none;
+        font-size: 0.875rem;
+        font-weight: 500;
+      }
+    }
+
+    @media (min-width: 769px) {
+      .mobile-back { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="logo-section">
+        <a href="/" class="logo">
+          <img src="https://raw.githubusercontent.com/datum-cloud/awesome-alt-clouds/main/altclouds-logo.png" alt="Alt Clouds" class="logo-img">
+          <div class="logo-text">
+            <h1>Awesome Alt Clouds</h1>
+          </div>
+        </a>
+        <p class="tagline">When you Need Something .. Specialized!</p>
+      </div>
+
+      <nav class="sidebar-nav">
+        <a href="/" class="nav-item">
+          <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m0 0l7-7m-7 7l7 7"></path>
+          </svg>
+          Directory
+        </a>
+        <a href="watchlist.html" class="nav-item active">
+          <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+          </svg>
+          Watchlist
+        </a>
+      </nav>
+
+      <div class="sidebar-bottom">
+        <a href="submit/" class="contribute-btn">
+          <span>+</span>
+          <span>Submit a Cloud</span>
+        </a>
+      </div>
+    </aside>
+
+    <!-- Main content -->
+    <main class="main-content">
+      <!-- Mobile back link -->
+      <a href="/" class="mobile-back">
+        <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m0 0l7-7m-7 7l7 7"></path>
+        </svg>
+        Back to Directory
+      </a>
+
+      <div class="page-header">
+        <h2 class="page-title">Watchlist</h2>
+        <p class="page-subtitle">
+          Services that have been submitted multiple times but don't yet meet the inclusion criteria.
+          They're tracked here with a clear path to qualification — no more re-litigating the same decisions.
+        </p>
+      </div>
+
+      <div class="info-strip" id="infoStrip">
+        <div class="info-card">
+          <div class="info-card-label">Tracking</div>
+          <div class="info-card-value" id="entryCount">—</div>
+        </div>
+        <div class="info-card">
+          <div class="info-card-label">Qualify at</div>
+          <div class="info-card-value">2 / 3 criteria</div>
+        </div>
+        <div class="info-card">
+          <div class="info-card-label">Review cadence</div>
+          <div class="info-card-value">Quarterly</div>
+        </div>
+        <div class="info-card">
+          <div class="info-card-label">Stale after</div>
+          <div class="info-card-value">6 months</div>
+        </div>
+      </div>
+
+      <div class="cards-grid" id="cardsGrid">
+        <!-- Cards injected by JS -->
+      </div>
+
+      <div class="rules-section">
+        <h3 class="rules-title">How It Works</h3>
+        <div class="rules-grid">
+          <div class="rule-card">
+            <div class="rule-card-title">Getting on the list</div>
+            <div class="rule-card-body">
+              Services submitted two or more times with continued community interest land here instead of being closed quietly.
+            </div>
+          </div>
+          <div class="rule-card">
+            <div class="rule-card-title">Getting promoted</div>
+            <div class="rule-card-body">
+              Score 2/3 or higher on a fresh evaluation. Open a new submission or comment on the original issue with evidence that the missing criteria are now met.
+            </div>
+          </div>
+          <div class="rule-card">
+            <div class="rule-card-title">Getting removed</div>
+            <div class="rule-card-body">
+              Promoted to the main list, no progress for 6 months, or the service shuts down. Maintainers review quarterly.
+            </div>
+          </div>
+          <div class="rule-card">
+            <div class="rule-card-title">Criteria to qualify</div>
+            <div class="rule-card-body">
+              Transparent public pricing page, usage-based self-service signup, and a public SLA or status page. Any 2 of 3 is enough.
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    async function load() {
+      const grid = document.getElementById('cardsGrid');
+      const countEl = document.getElementById('entryCount');
+
+      let entries = [];
+      try {
+        const res = await fetch('watchlist.json');
+        if (!res.ok) throw new Error(res.status);
+        entries = await res.json();
+      } catch (e) {
+        grid.innerHTML = '<div class="empty-state"><div class="empty-icon">&#9729;</div><p>Could not load watchlist data.</p></div>';
+        return;
+      }
+
+      const plural = entries.length === 1 ? 'candidate' : 'candidates';
+      countEl.textContent = `${entries.length} ${plural}`;
+
+      if (entries.length === 0) {
+        grid.innerHTML = '<div class="empty-state"><div class="empty-icon">&#9989;</div><p>No entries on the watchlist right now.</p></div>';
+        return;
+      }
+
+      grid.innerHTML = entries.map(e => {
+        const initial = e.name.charAt(0).toUpperCase();
+        let logoHtml;
+        try {
+          const hostname = new URL(e.url).hostname;
+          const logoUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
+          logoHtml = `<img src="${logoUrl}" alt="${initial}" onerror="this.style.display='none';this.parentElement.setAttribute('data-logo','${initial}');">`;
+        } catch {
+          logoHtml = initial;
+        }
+
+        return `
+          <div class="watch-card">
+            <div class="watch-card-header">
+              <div class="watch-logo" data-logo="${initial}">${logoHtml}</div>
+              <div>
+                <div class="watch-name">${e.name}</div>
+                <div class="watch-category">${e.category}</div>
+              </div>
+            </div>
+            <div class="watch-reason">
+              <div class="watch-reason-label">Why it's not listed</div>
+              ${e.reasonNotQualifying}
+            </div>
+            <div class="watch-criteria">
+              <div class="watch-criteria-label">What would qualify it</div>
+              ${e.criteriaNeed}
+            </div>
+            <div class="watch-footer">
+              <div class="watch-meta">Added ${e.dateAdded} · Reviewed ${e.lastReviewed}</div>
+              <a href="${e.url}" target="_blank" rel="noopener" class="watch-url">
+                Visit
+                <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        `;
+      }).join('');
+    }
+
+    load();
+  </script>
+</body>
+</html>

--- a/docs/watchlist.json
+++ b/docs/watchlist.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Iren",
+    "url": "https://iren.com",
+    "category": "GPU & AI Compute Clouds",
+    "dateAdded": "2026-03-18",
+    "reasonNotQualifying": "Score 1/3: no transparent pricing, no self-service signup",
+    "criteriaNeed": "Public pricing page; self-service signup",
+    "lastReviewed": "2026-05-21"
+  }
+]

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -2,11 +2,15 @@
 """
 Duplicate detection for awesome-alt-clouds submissions.
 
-Reads submission info from environment variables, checks clouds.json
-(the authoritative list from README.md) for duplicates, posts a comment
-+ label + optionally closes the issue, then writes is_duplicate=true/false
-to $GITHUB_OUTPUT.
+Checks two sources in order:
+  1. clouds.json — blocks re-submission of already-listed services.
+  2. watchlist.json — flags re-submissions of watched candidates without
+     blocking them; lets the normal evaluation run so they can be promoted.
 
+Closed GitHub Issues are intentionally NOT checked. A declined submission
+must be able to re-submit freely — that is the whole point of the watchlist.
+
+Writes is_duplicate=true/false to $GITHUB_OUTPUT.
 Exits 0 always — failures are non-fatal to avoid blocking submissions.
 """
 
@@ -168,8 +172,9 @@ def build_comment(match_type: str, match: dict) -> str:
         raise ValueError(f'Unknown match_type: {match_type!r}')
 
 
-# Path to clouds.json — overridable in tests
+# Paths to data files — overridable in tests
 _CLOUDS_JSON_PATH = os.path.join(os.path.dirname(__file__), '..', 'docs', 'clouds.json')
+_WATCHLIST_JSON_PATH = os.path.join(os.path.dirname(__file__), '..', 'docs', 'watchlist.json')
 
 
 def _write_github_output(key: str, value: str) -> None:
@@ -211,9 +216,9 @@ def main() -> None:
     submitted_domain = normalize_domain(urls[0])
     submitted_name = issue_title
 
-    # Check clouds.json — the authoritative list derived from README.md.
-    # GitHub Issues are intentionally NOT checked: a previously-rejected submission
-    # should not block a valid resubmission.
+    # 1. Check clouds.json — the authoritative list derived from README.md.
+    #    Closed GitHub Issues are intentionally NOT checked: a previously-rejected
+    #    submission must be able to re-submit freely.
     clouds: list[dict] = []
     try:
         with open(_CLOUDS_JSON_PATH, 'r', encoding='utf-8') as f:
@@ -232,6 +237,39 @@ def main() -> None:
             close_issue(repo, issue_number, gh_token)
         _write_github_output('is_duplicate', 'true')
         _write_github_output('duplicate_reason', match_type)
+        return
+
+    # 2. Check watchlist.json — flag re-submissions of watched candidates so
+    #    reviewers know this is a repeat attempt, but do NOT block evaluation.
+    #    The service may have improved; let the evaluator decide.
+    watchlist: list[dict] = []
+    try:
+        with open(_WATCHLIST_JSON_PATH, 'r', encoding='utf-8') as f:
+            watchlist = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logging.warning('Could not read watchlist.json: %s', e)
+
+    watchlist_match = next(
+        (entry for entry in watchlist if normalize_domain(entry.get('url', '')) == submitted_domain),
+        None,
+    )
+
+    if watchlist_match:
+        criteria = watchlist_match.get('criteriaNeed', 'see watchlist')
+        comment = (
+            '📋 **Watchlist Re-submission**\n\n'
+            f'This service is currently on the [Watchlist](https://alt-clouds.org/watchlist.html) '
+            f'and is being re-evaluated. Previously it did not qualify because: '
+            f'_{watchlist_match.get("reasonNotQualifying", "criteria not met")}_\n\n'
+            f'**Criteria still needed:** {criteria}\n\n'
+            'Proceeding with a fresh evaluation — if the criteria above are now met, '
+            'this submission will be promoted to the main list automatically.'
+        )
+        post_comment(repo, issue_number, comment, gh_token)
+        add_label(repo, issue_number, 'watchlist', gh_token)
+        # is_duplicate stays false — evaluation must run
+        _write_github_output('is_duplicate', 'false')
+        _write_github_output('duplicate_reason', 'watchlist_resubmission')
     else:
         _write_github_output('is_duplicate', 'false')
         _write_github_output('duplicate_reason', 'no_match')

--- a/scripts/generate_watchlist_json.py
+++ b/scripts/generate_watchlist_json.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Parse WATCHLIST.md and generate docs/watchlist.json."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+WATCHLIST_MD = Path("WATCHLIST.md")
+OUTPUT = Path("docs/watchlist.json")
+
+
+def parse_watchlist(content: str) -> list[dict]:
+    entries = []
+    in_table = False
+
+    for line in content.splitlines():
+        line = line.strip()
+
+        if line.startswith("| Name |"):
+            in_table = True
+            continue
+
+        if not in_table:
+            continue
+
+        if not line.startswith("|"):
+            in_table = False
+            continue
+
+        # Skip separator rows
+        if re.match(r"^\|[-| ]+\|$", line):
+            continue
+
+        parts = [p.strip() for p in line.split("|")]
+        # Remove empty strings from leading/trailing pipes
+        parts = [p for p in parts if p]
+
+        if len(parts) < 7:
+            continue
+
+        # Skip header row if we somehow re-encounter it
+        if parts[0].lower() == "name":
+            continue
+
+        entries.append({
+            "name": parts[0],
+            "url": parts[1],
+            "category": parts[2],
+            "dateAdded": parts[3],
+            "reasonNotQualifying": parts[4],
+            "criteriaNeed": parts[5],
+            "lastReviewed": parts[6],
+        })
+
+    return entries
+
+
+def main() -> None:
+    if not WATCHLIST_MD.exists():
+        print(f"ERROR: {WATCHLIST_MD} not found", file=sys.stderr)
+        sys.exit(1)
+
+    content = WATCHLIST_MD.read_text(encoding="utf-8")
+    entries = parse_watchlist(content)
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(entries, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"Generated {OUTPUT} with {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watchlist_add.py
+++ b/scripts/watchlist_add.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Add a declined submission to WATCHLIST.md.
+
+Required env vars:
+  ISSUE_NUMBER              - GitHub issue number
+  GH_TOKEN or GITHUB_TOKEN  - GitHub token for API access
+  REPO or GITHUB_REPOSITORY - GitHub repo in owner/name format
+"""
+
+import os
+import re
+import sys
+import requests
+from datetime import date
+
+WATCHLIST_FILE = "WATCHLIST.md"
+TABLE_SEP_PREFIX = "|------|-----|"
+
+
+def get_comments(repo, issue_number, token):
+    headers = {"Authorization": f"token {token}"}
+    r = requests.get(
+        f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
+        headers=headers,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def parse_evaluation(comments):
+    for comment in comments:
+        body = comment.get("body", "")
+        if "Evaluation Results" not in body:
+            continue
+
+        name_m = re.search(r"###\s+(.+)", body)
+        url_m = re.search(r"\*\*URL:\*\*\s*(https?://[^\s\n]+)", body)
+        score_m = re.search(r"\*\*Score:\*\*\s*(\d)/3", body)
+        cat_m = re.search(r"\*\*Category:\*\*\s*(.+)", body)
+
+        failed = []
+        for line in body.split("\n"):
+            if ":x:" not in line and "❌" not in line:
+                continue
+            parts = [p.strip() for p in line.split("|") if p.strip()]
+            if len(parts) >= 2 and (":x:" in parts[1] or "❌" in parts[1]):
+                criteria_name = parts[0]
+                if criteria_name and criteria_name.lower() != "status":
+                    failed.append(criteria_name)
+
+        return {
+            "name": name_m.group(1).strip() if name_m else None,
+            "url": url_m.group(1).strip() if url_m else None,
+            "score": score_m.group(1) if score_m else "?",
+            "category": cat_m.group(1).strip() if cat_m else "To be determined",
+            "failed": failed,
+        }
+    return {}
+
+
+def add_to_watchlist(name, url, category, reason, criteria, today):
+    with open(WATCHLIST_FILE) as f:
+        content = f.read()
+
+    url_base = url.rstrip("/")
+    if url_base in content:
+        print(f"  {url} already in watchlist — skipping.")
+        return False
+
+    sep_pos = content.find(TABLE_SEP_PREFIX)
+    if sep_pos == -1:
+        print(f"ERROR: Could not find table separator in {WATCHLIST_FILE}")
+        sys.exit(1)
+
+    # Find end of the separator line
+    newline_pos = content.index("\n", sep_pos)
+    new_row = f"\n| {name} | {url} | {category} | {today} | {reason} | {criteria} | {today} |"
+    content = content[:newline_pos] + new_row + content[newline_pos:]
+
+    with open(WATCHLIST_FILE, "w") as f:
+        f.write(content)
+
+    print(f"  Added {name} ({url}) to watchlist.")
+    return True
+
+
+def main():
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("REPO") or os.environ.get("GITHUB_REPOSITORY")
+    issue_number = os.environ.get("ISSUE_NUMBER")
+
+    if not all([token, repo, issue_number]):
+        print("ERROR: Required env vars: GH_TOKEN, REPO (or GITHUB_REPOSITORY), ISSUE_NUMBER")
+        sys.exit(1)
+
+    print(f"Processing issue #{issue_number} in {repo}")
+    comments = get_comments(repo, issue_number, token)
+    data = parse_evaluation(comments)
+
+    if not data.get("url"):
+        print("ERROR: No evaluation comment found or could not parse URL. "
+              "Ensure the bot has evaluated this issue before running /watchlist.")
+        sys.exit(1)
+
+    name = data["name"] or f"Issue #{issue_number}"
+    url = data["url"]
+    category = data.get("category", "To be determined")
+    score = data.get("score", "?")
+    failed = data.get("failed", [])
+
+    if failed:
+        reason = f"Score {score}/3: {'; '.join(c.lower() for c in failed)}"
+        criteria = "; ".join(failed)
+    else:
+        reason = f"Score {score}/3: criteria not met"
+        criteria = "See evaluation results"
+
+    today = date.today().isoformat()
+    added = add_to_watchlist(name, url, category, reason, criteria, today)
+
+    # Write name for use in commit message
+    with open("/tmp/watchlist_name.txt", "w") as f:
+        f.write(name)
+
+    if not added:
+        # Nothing changed — signal to workflow to skip commit
+        with open("/tmp/watchlist_changed.txt", "w") as f:
+            f.write("false")
+    else:
+        with open("/tmp/watchlist_changed.txt", "w") as f:
+            f.write("true")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `WATCHLIST.md` tracking services submitted 2+ times that don't yet qualify, seeded with "Iren" (3 submissions, score 1/3 each time)
- `/watchlist` slash command for maintainers to add entries; workflow commits `WATCHLIST.md` + regenerates `watchlist.json` atomically
- `check_duplicates.py` now checks watchlist re-submissions: flags them with a comment/label but **does not block** evaluation — the service gets a fresh pass and is promoted automatically if it now qualifies. Closed issues are explicitly not checked.
- `generate_watchlist_json.py` parses `WATCHLIST.md` → `docs/watchlist.json`; `deploy-pages.yml` runs it on every `WATCHLIST.md` push
- `docs/watchlist.html` is a browseable candidate page at alt-clouds.org, linked from the main directory sidebar (desktop + mobile drawer)
- `CONTRIBUTING.md` updated with a "Borderline Submissions" section pointing submitters to the watchlist

## Test plan

- [ ] Open a new submission issue for a watchlist entry (e.g. iren.com) — confirm it gets a `watchlist` label and explanatory comment, and evaluation still runs
- [ ] Comment `/watchlist` on a declined submission issue as a maintainer — confirm WATCHLIST.md and watchlist.json are updated and a confirmation comment is posted
- [ ] Comment `/watchlist` as a non-maintainer — confirm permission error comment is posted and no changes are made
- [ ] Visit `/watchlist.html` on the site — confirm Iren card renders with correct reason, criteria, and dates
- [ ] Push a change to `WATCHLIST.md` on main — confirm `deploy-pages.yml` regenerates `watchlist.json`

Closes #163