### PR TITLE
fix: dupe detector false positives, /revalidate command, watchlist potential framing (#115)

### DIFF
--- a/.github/workflows/revalidate-submission.yml
+++ b/.github/workflows/revalidate-submission.yml
@@ -1,0 +1,77 @@
+name: Revalidate Submission
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  revalidate:
+    # Trigger: maintainer comments /revalidate on any submission issue
+    # Use case: issue was incorrectly flagged as duplicate and needs a fresh evaluation
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'submission') &&
+      startsWith(github.event.comment.body, '/revalidate')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check permissions
+        id: check-permission
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['admin', 'maintain', 'write'].includes(perm.permission);
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} You don't have permission to revalidate submissions.`,
+              });
+            }
+            core.setOutput('allowed', String(allowed));
+
+      - name: Reset labels and re-trigger evaluation
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+
+            // Remove labels that block or mis-categorise the submission
+            for (const label of ['duplicate', 'needs-review', 'auto-approved', 'approved', 'watchlist']) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+              } catch (_) {
+                // Label not present — ignore
+              }
+            }
+
+            // Remove then re-add 'submission' using the App token so GitHub
+            // fires a real 'labeled' event, which re-triggers evaluate-submission.yml.
+            // (GITHUB_TOKEN label events are suppressed and would not re-trigger.)
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'submission' });
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['submission'] });
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: `🔄 **Revalidation triggered by @${context.actor}**\n\nLabels have been reset and a fresh evaluation is running now.`,
+            });

--- a/.github/workflows/watchlist.yml
+++ b/.github/workflows/watchlist.yml
@@ -101,9 +101,18 @@ jobs:
               ? fs.readFileSync('/tmp/watchlist_name.txt', 'utf8').trim()
               : 'This service';
 
-            const body = changed === 'true'
-              ? `📋 **Added to Watchlist**\n\n${name} has been added to [WATCHLIST.md](../blob/main/WATCHLIST.md). It will be re-evaluated once the criteria listed in the evaluation results above have been addressed.`
-              : `ℹ️ **Already on Watchlist**\n\n${name} is already tracked in [WATCHLIST.md](../blob/main/WATCHLIST.md).`;
+            const skipReason = fs.existsSync('/tmp/watchlist_skip_reason.txt')
+              ? fs.readFileSync('/tmp/watchlist_skip_reason.txt', 'utf8').trim()
+              : '';
+
+            let body;
+            if (skipReason === 'score_zero') {
+              body = `⛔ **Not added to Watchlist**\n\n${name} scored 0/3 — no qualifying signals (no pricing, no self-service, no status page). The watchlist tracks services with real potential: at least one criterion already met. A 0/3 submission has nothing to build on and should be closed.`;
+            } else if (changed === 'true') {
+              body = `📋 **Added to Watchlist**\n\n${name} has been added to [WATCHLIST.md](../blob/main/WATCHLIST.md). It will be re-evaluated once the criteria listed in the evaluation results above have been addressed.`;
+            } else {
+              body = `ℹ️ **Already on Watchlist**\n\n${name} is already tracked in [WATCHLIST.md](../blob/main/WATCHLIST.md).`;
+            }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,16 @@ We welcome additions, corrections, and improvements to this list of alternative 
 
 ## Borderline Submissions
 
-If your submission doesn't meet all three criteria yet, it may be added to the [Watchlist](WATCHLIST.md) instead of being rejected outright. The watchlist tracks promising candidates with a clear path to qualification.
+The [Watchlist](WATCHLIST.md) tracks services that show real potential but haven't crossed the qualification threshold yet.
 
-A submission lands on the watchlist when:
-- It scores 1/3 on the automated evaluation, **and**
-- A maintainer judges it worth tracking (e.g. the service is actively improving or is widely referenced in the community).
+| Score | Outcome |
+|-------|---------|
+| 0 / 3 | Declined. No pricing, no self-service, no status page — nothing to build on. |
+| 1 / 3 | Watchlist candidate. One signal is present; a maintainer may add it to track progress. |
+| 2 / 3 | Included (needs-review). A PR is opened automatically for admin sign-off. |
+| 3 / 3 | Included automatically. |
 
-Check the watchlist before re-submitting — your service may already be tracked there. To trigger a re-evaluation, comment on your original submission issue with evidence that the missing criteria are now met, or open a new submission.
+If your service lands on the watchlist, the "Criteria Needed" column shows exactly what must change. Address those gaps and re-submit, or comment on your original issue with evidence that the missing criteria are now met.
 
 💬 For questions or suggestions, feel free to [open an issue](https://github.com/datum-cloud/awesome-alt-clouds/issues).
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Alt Clouds provide value "as a service" directly on top of infrastructure. They 
 ## Contents
 
 * [Criteria](#criteria)
+* [Watchlist](WATCHLIST.md) — candidates submitted 2+ times that don't yet qualify
 * [Infrastructure Clouds](#infrastructure-clouds)
 * [GPU & AI Compute Clouds](#gpu--ai-compute-clouds)
 * [Security, Compliance & Sovereignty Clouds](#security-compliance--sovereignty-clouds)

--- a/WATCHLIST.md
+++ b/WATCHLIST.md
@@ -1,8 +1,8 @@
 # Watchlist
 
-Candidates submitted to Awesome Alt Clouds that don't yet meet inclusion criteria. This list provides a transparent path forward for promising services and prevents the same submissions from being re-litigated from scratch.
+Services that show **real potential** but haven't crossed the qualification threshold yet. Potential means the service already meets at least one of the three criteria — it exists, it's production-grade in some way, and is moving in the right direction.
 
-Only companies submitted **two or more times** with continued community interest are tracked here — a signal that the service is worth watching even though it hasn't qualified yet.
+A score of 0/3 means no pricing, no self-service, and no status page — nothing to build on. Those submissions are declined outright. This list is for 1/3 cases: one signal is there, two are missing. That gap is closeable.
 
 ## How It Works
 
@@ -10,7 +10,7 @@ Only companies submitted **two or more times** with continued community interest
 
 **Community** — If you have evidence that a listed candidate now meets its missing criteria, comment on the original submission issue.
 
-**Maintainers** — Add entries by commenting `/watchlist` on any submission issue. Review the list quarterly and update "Last Reviewed" dates.
+**Maintainers** — Add entries by commenting `/watchlist` on a submission issue that scored 1/3. The bot will reject the command if the score is 0/3. Review the list quarterly.
 
 ## Promotion Rules
 

--- a/docs/watchlist.html
+++ b/docs/watchlist.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Watchlist | Awesome Alt Clouds</title>
-  <meta name="description" content="Candidates submitted to Awesome Alt Clouds that don't yet meet inclusion criteria — tracked here with a clear path to qualification.">
+  <meta name="description" content="Services with real potential that don't yet meet the Alt Clouds inclusion criteria — tracked here with a clear path to qualification.">
   <link rel="canonical" href="https://www.alt-clouds.org/watchlist.html">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -447,8 +447,9 @@
       <div class="page-header">
         <h2 class="page-title">Watchlist</h2>
         <p class="page-subtitle">
-          Services that have been submitted multiple times but don't yet meet the inclusion criteria.
-          They're tracked here with a clear path to qualification — no more re-litigating the same decisions.
+          Services with real potential that haven't crossed the qualification threshold yet.
+          Potential means at least one criterion is already met — the gap is closeable.
+          A 0/3 score gets declined outright; only 1/3 gets tracked here.
         </p>
       </div>
 
@@ -458,8 +459,8 @@
           <div class="info-card-value" id="entryCount">—</div>
         </div>
         <div class="info-card">
-          <div class="info-card-label">Qualify at</div>
-          <div class="info-card-value">2 / 3 criteria</div>
+          <div class="info-card-label">Minimum to enter</div>
+          <div class="info-card-value">1 / 3 criteria</div>
         </div>
         <div class="info-card">
           <div class="info-card-label">Review cadence</div>
@@ -481,13 +482,13 @@
           <div class="rule-card">
             <div class="rule-card-title">Getting on the list</div>
             <div class="rule-card-body">
-              Services submitted two or more times with continued community interest land here instead of being closed quietly.
+              A service must score 1/3 — at least one real qualifying signal. Score 0/3 means no pricing, no self-service, no status page: nothing to build on, so it's declined outright.
             </div>
           </div>
           <div class="rule-card">
             <div class="rule-card-title">Getting promoted</div>
             <div class="rule-card-body">
-              Score 2/3 or higher on a fresh evaluation. Open a new submission or comment on the original issue with evidence that the missing criteria are now met.
+              Score 2/3 or higher on a fresh evaluation. Re-submit or comment on the original issue with evidence that the missing criteria are now met.
             </div>
           </div>
           <div class="rule-card">

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -57,15 +57,17 @@ def normalize_name(name: str) -> str:
     """Normalise a service name for fuzzy matching.
 
     Lowercases, strips punctuation, removes noise words.
-    Example: 'ZeroTier Labs' -> 'zerotier'
+    Returns space-separated tokens to preserve word boundaries.
+
+    Examples:
+        'ZeroTier Labs' -> 'zerotier'
+        'Namecheap'     -> 'namecheap'
+        'Heap'          -> 'heap'
     """
-    # lowercase
     name = name.lower()
-    # replace punctuation with spaces (preserve word boundaries)
     name = re.sub(r'[^a-z0-9\s]', ' ', name)
-    # remove noise words
     parts = [w for w in name.split() if w not in _NAME_NOISE]
-    return ''.join(parts)
+    return ' '.join(parts)
 
 
 def check_clouds_json(
@@ -89,14 +91,16 @@ def check_clouds_json(
         if entry_domain and entry_domain == submitted_domain:
             return ('exact_domain', entry)
 
-        # Fuzzy name check (only keep first match, require min length to avoid false positives)
+        # Fuzzy name check: token-set intersection (not character substring).
+        # Character substring matching caused false positives like flagging
+        # "Namecheap" as a duplicate of "Heap" because 'heap' ⊆ 'namecheap'.
         if fuzzy_match is None and len(norm_submitted_name) >= 4:
             norm_entry_name = normalize_name(entry.get('name', ''))
-            if norm_entry_name and len(norm_entry_name) >= 4 and (
-                norm_submitted_name in norm_entry_name
-                or norm_entry_name in norm_submitted_name
-            ):
-                fuzzy_match = entry
+            if norm_entry_name and len(norm_entry_name) >= 4:
+                submitted_tokens = {t for t in norm_submitted_name.split() if len(t) >= 4}
+                entry_tokens = {t for t in norm_entry_name.split() if len(t) >= 4}
+                if submitted_tokens and entry_tokens and submitted_tokens & entry_tokens:
+                    fuzzy_match = entry
 
     if fuzzy_match is not None:
         return ('fuzzy_name', fuzzy_match)

--- a/scripts/watchlist_add.py
+++ b/scripts/watchlist_add.py
@@ -108,6 +108,24 @@ def main():
     score = data.get("score", "?")
     failed = data.get("failed", [])
 
+    # Only track services that show at least one qualifying signal.
+    # Score 0/3 means no pricing, no self-service, and no status page —
+    # there is nothing to build on and no path worth tracking.
+    try:
+        score_int = int(score)
+    except (ValueError, TypeError):
+        score_int = -1
+
+    if score_int == 0:
+        print(f"  Score is 0/3 — no qualifying signals found. Not adding to watchlist.")
+        with open("/tmp/watchlist_changed.txt", "w") as f:
+            f.write("false")
+        with open("/tmp/watchlist_name.txt", "w") as f:
+            f.write(name)
+        with open("/tmp/watchlist_skip_reason.txt", "w") as f:
+            f.write("score_zero")
+        return
+
     if failed:
         reason = f"Score {score}/3: {'; '.join(c.lower() for c in failed)}"
         criteria = "; ".join(failed)


### PR DESCRIPTION
## Summary

- **fix: fuzzy name matcher false positives** — \`normalize_name\` was joining tokens with \`''\` so \`"heap" in "namecheap"\` was literally \`True\`, flagging Namecheap as a duplicate of Heap (#115). Switched to space-joined tokens + token-set intersection; tokens must be ≥ 4 chars each to drive a match.
- **feat: \`/revalidate\` slash command** — maintainers can comment \`/revalidate\` on any mis-flagged submission issue to reset labels and fire a fresh evaluation. Uses the GitHub App token so the re-added \`submission\` label fires a real \`labeled\` event (GITHUB_TOKEN label events are suppressed by GitHub).
- **feat: watchlist potential gate** — watchlist now only accepts 1/3 scores. Score 0/3 (no pricing, no self-service, no status page) is declined outright with a clear bot comment. Logic updated in \`watchlist_add.py\`, \`watchlist.yml\`, \`WATCHLIST.md\`, \`CONTRIBUTING.md\`, and \`watchlist.html\`.
- **docs: README watchlist link** — adds \`[Watchlist](WATCHLIST.md)\` to the Contents table.

## Test plan

- [ ] Comment \`/revalidate\` on issue #115 after merge — confirm \`duplicate\` label is removed, \`submission\` is re-added, and a fresh evaluation runs for Namecheap
- [ ] Submit a service that scores 0/3 and comment \`/watchlist\` — confirm bot replies with the ⛔ rejection message and nothing is added to WATCHLIST.md
- [ ] Submit a service that scores 1/3 and comment \`/watchlist\` — confirm entry is added to WATCHLIST.md and watchlist.json
- [ ] Submit a name that shares a substring but not a word with an existing entry (e.g. a service containing "heap") — confirm no false positive duplicate flag
- [ ] Visit \`/watchlist.html\` — confirm updated subtitle and "Minimum to enter 1 / 3" info card

Fixes #115