### PR TITLE
Add 8gears Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Platform-as-a-service and managed hosting providers for deploying and scaling we
 
 Build systems, artifact registries, CI/CD pipelines, cloud dev environments, testing frameworks, feature flags, and developer productivity tools.
 
+* 🟢 [8gears Container Registry](https://container-registry.com/) - Harbor-based enterprise container registry with vulnerability scanning, image signing, and replication, available managed or self-hosted.
 * 🟢 [Anaconda](https://www.anaconda.com/) - Provides enterprise Python package management and AI development platform with secure open-source libraries, environment management, and AI model deployment capabilities.
 * 🟢 [Browserbase](https://www.browserbase.com/) - A platform for running headless browsers for interact with websites via automation.
 * 🟢 [browserless](https://www.browserless.io/) - Headless browser automation platform providing managed Chrome, Firefox, and WebKit browsers for scraping, testing, and automation with bot detection bypass and CAPTCHA solving.


### PR DESCRIPTION
Adds **8gears Container Registry** to *Developer Tooling & CI/CD* (artifact registries).

* 🟢 [8gears Container Registry](https://container-registry.com/) - Harbor-based enterprise container registry with vulnerability scanning, image signing, and replication, available managed or self-hosted.

Alphabetized within the section; `scripts/parse_readme_to_json.py` parses the updated README without errors.

Meets all 3 criteria: public pricing ([pricing](https://container-registry.com/pricing/)), self-service signup, and a public status page ([statuspage.container-registry.com](https://statuspage.container-registry.com/)).
