### PR TITLE
Add CoderPlan to AI Inference & Model APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ APIs and platforms for running inference on foundation models and open-source LL
 
 * 🟡 [Anchor](https://anchorbrowser.io/) - Provides AI-powered browser automation infrastructure with humanized Chromium instances that can access any website, handle authentication, and perform web tasks reliably.
 * 🟡 [Cloudglue](https://cloudglue.dev/) - Provides a video context engine API that structures, searches, and enables AI reasoning over video content for developers building chatbots, RAG systems, and video analysis applications.
+* 🟡 [CoderPlan](https://coderplan.ai/) - LLM API Gateway with OpenAI-compatible interface providing pay-per-use access to Claude, GPT, Gemini, DeepSeek, and Grok models. One-line config for Claude Code, Codex CLI, and Gemini CLI.
 * 🟢 [Fireworks.ai](https://fireworks.ai/) - Delivers high-speed, cost-effective inference APIs with support for open-source models.
 * 🟢 [Groq](https://groq.com/) - Provides ultra-fast inference on custom hardware designed for AI workloads.
 * 🟢 [InfronAI](https://infron.ai/) - Provides unified access to 400+ AI models from 100+ providers with enterprise reliability, cost optimization, and zero data retention security features.


### PR DESCRIPTION
## Addition

**CoderPlan** — LLM API Gateway with OpenAI-compatible interface.

- **Public pricing**: [coderplan.ai/pricing](https://coderplan.ai/pricing) ✓
- **Self-service signup**: [coderplan.ai/register](https://coderplan.ai/register) ✓
- **SLA/status page**: Not yet available
- **Score**: 🟡 (2 of 3 criteria met)

### Why CoderPlan fits

CoderPlan provides pay-per-use access to Claude, GPT, Gemini, DeepSeek, and Grok models through an OpenAI-compatible API gateway. It is specifically designed for AI coding workflows — supporting one-line configuration for Claude Code, Codex CLI, and Gemini CLI. This makes it a natural fit alongside Portkey, Fireworks.ai, and Together.ai in the "AI Inference & Model APIs" section.

Added alphabetically (Cloudglue → **CoderPlan** → Fireworks.ai) with 🟡 per the scoring criteria.