### PR TITLE
fix(blog-posts): normalize STRAPI_URL to include https:// protocol

### DIFF
--- a/scripts/update_blog_posts.mjs
+++ b/scripts/update_blog_posts.mjs
@@ -75,10 +75,16 @@ async function main() {
     process.exit(1);
   }
 
+  // Ensure the URL includes a protocol — the secret may be stored as a bare hostname.
+  const strapiUrl =
+    STRAPI_URL.startsWith('http://') || STRAPI_URL.startsWith('https://')
+      ? STRAPI_URL
+      : `https://${STRAPI_URL}`;
+
   console.log(`Fetching articles from Strapi for author "${AUTHOR_SLUG}"…`);
 
   const { client, cache } = createStrapiRevalidate({
-    url: STRAPI_URL,
+    url: strapiUrl,
     token: STRAPI_TOKEN,
     cache: { driver: 'memory' },
   });


### PR DESCRIPTION
## Summary

- `createStrapiRevalidate` uses Zod's `z.string().url()` validator which requires a full URL with protocol
- The `STRAPI_URL` secret is stored as a bare hostname (no `https://` prefix), causing a `ZodError: Invalid url` on every run
- Normalizes `STRAPI_URL` in the script before passing it to `createStrapiRevalidate`: if the value already includes a protocol it's used as-is, otherwise `https://` is prepended

## Test plan

- [ ] Trigger Actions → Update Blog Posts → Run workflow manually and confirm it exits successfully
- [ ] Confirm blog post cards are updated in `docs/index.html`