### PR TITLE
ci(blog-posts): bump Node.js 20→22, drop missing automated label

### DIFF
--- a/.github/workflows/update-blog-posts.yml
+++ b/.github/workflows/update-blog-posts.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install @datum-cloud/strapi-revalidate
@@ -69,8 +69,7 @@ jobs:
               --title "Update blog posts from Zac Smith's author page" \
               --body "Automated daily update of blog posts. This PR is force-updated each run; closing it is safe — the next run will reopen if there are further changes." \
               --base main \
-              --head "$BRANCH" \
-              --label "automated"
+              --head "$BRANCH"
           else
             echo "Existing PR #$existing_pr refreshed via force-push."
           fi


### PR DESCRIPTION
Two fixes for the failing Update Blog Posts action:

- **Node.js 20→22**: Node 20 actions are deprecated, bumping to 22 (current LTS)
- **Remove `--label "automated"`**: label doesn't exist in this repo, causing `gh pr create` to exit 1

Both issues confirmed from run https://github.com/datum-cloud/awesome-alt-clouds/actions/runs/27259957845