### PR TITLE
fix(eval): disable Qwen3 thinking mode + Node.js 24 migration

### DIFF
--- a/.github/workflows/admin-approve-submission.yml
+++ b/.github/workflows/admin-approve-submission.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   approve:
     # Only run on issues (not PRs) with submission label when admin comments /approve or approve

--- a/.github/workflows/evaluate-submission.yml
+++ b/.github/workflows/evaluate-submission.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   evaluate:
     # Trigger conditions:

--- a/.github/workflows/split-submission.yml
+++ b/.github/workflows/split-submission.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   split:
     # Only run on submission issues that contain more than one real URL.

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -485,13 +485,15 @@ Respond in this exact JSON format only, no other text:
 
         message = client.chat.completions.create(
             model=QWEN_MODEL,
-            max_tokens=256,
+            max_tokens=1024,
             messages=[
                 {"role": "user", "content": prompt}
-            ]
+            ],
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}}
         )
 
-        response_text = message.choices[0].message.content.strip()
+        response_text = (message.choices[0].message.content or "").strip()
+        response_text = re.sub(r'<think>[\s\S]*?</think>', '', response_text).strip()
 
         # Parse JSON from response
         # Handle case where response might have markdown code blocks
@@ -573,10 +575,12 @@ Respond in this exact JSON format only, no other text:
         message = client.chat.completions.create(
             model=QWEN_MODEL,
             max_tokens=1024,
-            messages=[{"role": "user", "content": prompt}]
+            messages=[{"role": "user", "content": prompt}],
+            extra_body={"chat_template_kwargs": {"enable_thinking": False}}
         )
 
-        response_text = message.choices[0].message.content.strip()
+        response_text = (message.choices[0].message.content or "").strip()
+        response_text = re.sub(r'<think>[\s\S]*?</think>', '', response_text).strip()
 
         if not response_text:
             print(f"Qwen returned no text for {url}")


### PR DESCRIPTION
## Summary

- **Qwen3 empty response fix**: Qwen3 runs in thinking mode by default. With `max_tokens=256`, the `<think>` block consumed all tokens leaving `choices[0].message.content` empty → `json.loads("")` crashed with `Expecting value: line 1 column 1 (char 0)`. Fixed by:
  - `extra_body={"chat_template_kwargs": {"enable_thinking": False}}` on both API calls
  - `(content or "").strip()` to guard against `None` content
  - `re.sub(r'<think>[\s\S]*?</think>', ...)` to strip residual thinking blocks
  - `max_tokens` bumped 256 → 1024 for metadata generation
- **Node.js 24**: Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to `evaluate-submission`, `admin-approve-submission`, and `split-submission` workflows ahead of the June 16 forced migration

## Test plan

- [x] 21/21 tests pass locally
- [ ] Re-trigger issue #251 (`nofire.ai`) to confirm Qwen metadata generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)