### PR TITLE
feat: add Firefox add-on link to browser extension modal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1501,7 +1501,9 @@
             <span id="ext-yours-firefox" style="display:none; position: absolute; top: 0.625rem; right: 0.625rem; font-size: 0.625rem; font-weight: 700; letter-spacing: 0.06em; padding: 0.2rem 0.5rem; background: var(--soft-sage); color: #fff; border-radius: 99px;">YOURS</span>
             <img src="https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox.svg" width="40" height="40" alt="Mozilla Firefox"/>
             <span style="font-weight: 600; font-size: 0.9375rem; color: var(--text-primary);">Mozilla Firefox</span>
-            <button disabled class="ext-btn-disabled">Coming soon</button>
+            <a id="ext-btn-firefox" href="https://addons.mozilla.org/addon/alt-cloud-checker/" target="_blank" rel="noopener noreferrer" class="ext-btn">
+              <span>+</span><span id="ext-btn-firefox-label">Add to browser</span>
+            </a>
           </div>
 
           <!-- Microsoft Edge -->


### PR DESCRIPTION
## Summary

- Replaces the disabled "Coming soon" button in the Firefox card of the browser extension modal with a live "Add to browser" link
- Links to https://addons.mozilla.org/addon/alt-cloud-checker/
- Matches the existing Chrome card style (`ext-btn` class, `+` icon, labelled span)

## Test plan

- [ ] Open https://www.alt-cloud.org/ and click the "Browser extension" button
- [ ] Confirm the Firefox card shows an active "Add to browser" link
- [ ] Confirm clicking it opens the correct Mozilla Add-ons page
- [ ] Confirm the "YOURS" badge still appears when viewed in Firefox