### PR TITLE
Add Zerops to PaaS & Application Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Platform-as-a-service and managed hosting providers for deploying and scaling we
 * 🟢 [Shuttle](https://www.shuttle.dev/) - Rust-native cloud platform for building and deploying backend services.
 * 🟢 [Skyhook](https://skyhook.io/) - PaaS for deploying and managing Kubernetes clusters and workloads with GitOps support, preview environments, and AI assistance.
 * 🟢 [Upsun](https://upsun.com/) - An application hosting platform from the team at Platform.sh.
+* 🟢 [Zerops](https://zerops.io) – Developer cloud on bare metal with full Linux containers, hardware-only usage-based pricing, and managed Postgres, MariaDB, Valkey, and KeyDB on private networking.
 
 ## Developer Tooling & CI/CD
 


### PR DESCRIPTION
Adding Zerops to PaaS & Application Hosting.

Meets all three criteria:
- Transparent public pricing: https://zerops.io/#pricing (hardware-only, usage-based — no plans or seats)
- Usage-based self-service: self-service signup, billed by actual hardware consumption
- Production indicators: public status page at https://status.zerops.io

Zerops is a developer cloud built on bare metal with full Linux containers, SSH access, and managed databases (Postgres, MariaDB, Valkey, KeyDB) on project-private networking. Live since 2020.