### PR TITLE
Add Nuza to GPU & AI Compute Clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Specialized providers offering on-demand GPU clusters, serverless inference, and
 * 🟢 [Nebius](https://nebius.com/) - Provides AI-centric cloud infrastructure with large-scale GPU clusters and managed services.
 * 🟢 [NeevCloud](https://www.neevcloud.com/) - India-based GPU cloud offering secure, scalable AI compute.
 * 🟢 [NextGen Cloud](https://www.nextgencloud.com/) - Delivers sustainable, high-performance cloud infrastructure for AI workloads.
+* 🟡 [Nuza](https://nuza.io/) - GPU spot exchange on Solana with per-second billing in USDC, on-chain escrow with automatic refunds for unused time, and a public pricing API.
 * 🟢 [Ornn](https://ornn.com/) - Provides financial infrastructure for GPU compute markets, including reference pricing indices, market data, capacity financing, and compute access platforms.
 * 🟡 [Paperspace](https://www.paperspace.com/) - Cloud computing with GPU support for AI development and deployment. Now owned by DigitalOcean.
 * 🟢 [Parasail](https://parasail.ai/) - Serverless GPU platform to run custom AI models easily.


### PR DESCRIPTION
Submitting my own project. Nuza is a GPU spot exchange on Solana: per-second billing in USDC, self-service signup, and on-chain escrow with automatic refunds for unused time. Against your criteria it's a 🟡 (2/3): transparent public pricing and usage-based self-service, but no public status page yet — marked it accordingly.

Machine-checkable pricing API: https://nuza.io/api/v1/pricing (public settlement ledger at https://nuza.io/tape). Placed alphabetically in GPU & AI Compute Clouds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)