### PR TITLE
Detect duplicates via HTTP redirects and short exact-name matches

### DIFF
--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -3,7 +3,10 @@
 Duplicate detection for awesome-alt-clouds submissions.
 
 Checks two sources in order:
-  1. clouds.json — blocks re-submission of already-listed services.
+  1. clouds.json — blocks re-submission of already-listed services. Matches
+     on exact domain, fuzzy name (including exact-name equality for short
+     brand names), or a live HTTP redirect proving the submitted URL and an
+     existing entry resolve to the same domain (e.g. 'ory.sh' -> 'ory.com').
   2. watchlist.json — flags re-submissions of watched candidates without
      blocking them; lets the normal evaluation run so they can be promoted.
 
@@ -94,9 +97,18 @@ def check_clouds_json(
         # Fuzzy name check: token-set intersection (not character substring).
         # Character substring matching caused false positives like flagging
         # "Namecheap" as a duplicate of "Heap" because 'heap' ⊆ 'namecheap'.
-        if fuzzy_match is None and len(norm_submitted_name) >= 4:
+        if fuzzy_match is None and norm_submitted_name:
             norm_entry_name = normalize_name(entry.get('name', ''))
-            if norm_entry_name and len(norm_entry_name) >= 4:
+            if not norm_entry_name:
+                continue
+            # Exact match after normalisation, regardless of length. Without
+            # this, short brand names (e.g. "Ory" -> 'ory', 3 chars) never
+            # reach the token-overlap check below and go undetected even
+            # when submitted under the identical name.
+            if norm_submitted_name == norm_entry_name:
+                fuzzy_match = entry
+                continue
+            if len(norm_submitted_name) >= 4 and len(norm_entry_name) >= 4:
                 submitted_tokens = {t for t in norm_submitted_name.split() if len(t) >= 4}
                 entry_tokens = {t for t in norm_entry_name.split() if len(t) >= 4}
                 if submitted_tokens and entry_tokens and submitted_tokens & entry_tokens:
@@ -104,6 +116,69 @@ def check_clouds_json(
 
     if fuzzy_match is not None:
         return ('fuzzy_name', fuzzy_match)
+
+    return (None, None)
+
+
+def resolve_final_domain(url: str, timeout: int = 10) -> str:
+    """Follow redirects for `url` and return the normalised domain it lands on.
+
+    Used to catch cases where two different domains are actually the same
+    site (e.g. 'ory.sh' 301-redirects to 'ory.com'). This is a live HTTP
+    check, not a heuristic — a matched result is verified, not guessed.
+
+    Returns '' on any failure (timeout, connection error, invalid URL, etc.)
+    so callers can fail open and fall back to non-redirect-based matching.
+    """
+    try:
+        headers = {'User-Agent': 'Mozilla/5.0 (compatible; AwesomeAltCloudsBot/1.0)'}
+        resp = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True, stream=True)
+        resp.close()
+        return normalize_domain(resp.url)
+    except Exception as e:
+        logging.warning('Failed to resolve redirects for %s: %s', url, e)
+        return ''
+
+
+def check_clouds_json_with_redirects(
+    submitted_domain: str,
+    submitted_name: str,
+    submitted_url: str,
+    clouds: list[dict],
+) -> tuple[str | None, dict | None]:
+    """Wrap check_clouds_json with a targeted, live redirect check.
+
+    Never scans all entries over the network — at most two live requests:
+    one for the submitted URL, and (only if a fuzzy name candidate was
+    found) one for that candidate's stored URL.
+
+    Adds a third match type:
+        ('redirect_domain', entry) — an HTTP redirect proves the submitted
+        URL and an existing entry resolve to the same domain.
+    """
+    match_type, match = check_clouds_json(submitted_domain, submitted_name, clouds)
+
+    if match_type == 'exact_domain':
+        return (match_type, match)
+
+    submitted_final = resolve_final_domain(submitted_url)
+
+    if match_type == 'fuzzy_name':
+        candidate_final = resolve_final_domain(match.get('url', ''))
+        if submitted_final and candidate_final and submitted_final == candidate_final:
+            return ('redirect_domain', match)
+        return (match_type, match)
+
+    # No name/domain match at all — check whether the submitted URL silently
+    # redirects to an already-listed domain (e.g. a rebrand with a new name
+    # but a forwarding old domain).
+    if submitted_final and submitted_final != submitted_domain:
+        redirect_match = next(
+            (entry for entry in clouds if normalize_domain(entry.get('url', '')) == submitted_final),
+            None,
+        )
+        if redirect_match:
+            return ('redirect_domain', redirect_match)
 
     return (None, None)
 
@@ -172,6 +247,14 @@ def build_comment(match_type: str, match: dict) -> str:
             f'- **[{name}]({url})** — {desc}\n\n'
             'Proceeding with admin review, but flagging as a possible duplicate.'
         )
+    elif match_type == 'redirect_domain':
+        return (
+            '🔁 **Duplicate via Domain Redirect**\n\n'
+            'This URL redirects to a service already listed in Awesome Alt Clouds '
+            '(confirmed via HTTP redirect, not just name similarity):\n'
+            f'- **[{name}]({url})** — {desc}\n\n'
+            'Proceeding with admin review, but flagging as a likely duplicate.'
+        )
     else:
         raise ValueError(f'Unknown match_type: {match_type!r}')
 
@@ -230,7 +313,7 @@ def main() -> None:
     except (OSError, json.JSONDecodeError) as e:
         logging.warning('Could not read clouds.json: %s', e)
 
-    match_type, match = check_clouds_json(submitted_domain, submitted_name, clouds)
+    match_type, match = check_clouds_json_with_redirects(submitted_domain, submitted_name, urls[0], clouds)
 
     if match_type is not None:
         assert match is not None, f"match_type is {match_type!r} but match is None"

--- a/tests/test_check_duplicates.py
+++ b/tests/test_check_duplicates.py
@@ -149,6 +149,168 @@ class TestCheckCloudsJson:
         match_type, entry = cd.check_clouds_json('other.io', 'Render', clouds)
         assert match_type == 'fuzzy_name'
 
+    def test_short_exact_name_match_below_token_length_gate(self):
+        # 'Ory' normalises to 'ory' (3 chars) — below the >=4 token-overlap
+        # gate, but an exact match after normalisation should still fire.
+        clouds = [{
+            "name": "Ory",
+            "url": "https://www.ory.sh/",
+            "description": "Open-source identity infrastructure.",
+            "score": 3,
+            "categories": [],
+        }]
+        match_type, entry = cd.check_clouds_json('ory.com', 'Ory', clouds)
+        assert match_type == 'fuzzy_name'
+        assert entry['name'] == 'Ory'
+
+    def test_short_different_names_do_not_match(self):
+        # Two distinct short names should not collide.
+        clouds = [{
+            "name": "Fly",
+            "url": "https://fly.io",
+            "description": "...",
+            "score": 3,
+            "categories": [],
+        }]
+        result = cd.check_clouds_json('other.io', 'Vex', clouds)
+        assert result == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_final_domain
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFinalDomain:
+
+    def _mock_response(self, final_url):
+        mock = MagicMock()
+        mock.url = final_url
+        mock.close = MagicMock()
+        return mock
+
+    def test_no_redirect_returns_same_domain(self):
+        with patch('requests.get', return_value=self._mock_response('https://ory.com/')):
+            assert cd.resolve_final_domain('https://ory.com/') == 'ory.com'
+
+    def test_redirect_returns_final_domain(self):
+        with patch('requests.get', return_value=self._mock_response('https://www.ory.com/')):
+            assert cd.resolve_final_domain('https://www.ory.sh/') == 'ory.com'
+
+    def test_exception_returns_empty_string(self):
+        with patch('requests.get', side_effect=Exception('connection error')):
+            assert cd.resolve_final_domain('https://unreachable.example/') == ''
+
+    def test_timeout_returns_empty_string(self):
+        import requests as requests_module
+        with patch('requests.get', side_effect=requests_module.exceptions.Timeout('timed out')):
+            assert cd.resolve_final_domain('https://slow.example/') == ''
+
+
+# ---------------------------------------------------------------------------
+# check_clouds_json_with_redirects
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCloudsJsonWithRedirects:
+
+    ORY_CLOUDS = [{
+        "name": "Different Name Entirely",
+        "url": "https://www.ory.sh/",
+        "description": "Open-source identity infrastructure.",
+        "score": 3,
+        "categories": [],
+    }]
+
+    def test_exact_domain_short_circuits_without_network(self):
+        clouds = [{
+            "name": "Fly.io",
+            "url": "https://fly.io",
+            "description": "...",
+            "score": 3,
+            "categories": [],
+        }]
+        with patch('requests.get') as mock_get:
+            match_type, entry = cd.check_clouds_json_with_redirects(
+                'fly.io', 'Fly.io', 'https://fly.io', clouds,
+            )
+        assert match_type == 'exact_domain'
+        mock_get.assert_not_called()
+
+    def test_fuzzy_name_upgraded_to_redirect_domain_when_final_domains_match(self):
+        clouds = [{
+            "name": "Ory",
+            "url": "https://www.ory.sh/",
+            "description": "...",
+            "score": 3,
+            "categories": [],
+        }]
+
+        def fake_get(url, **kwargs):
+            resp = MagicMock()
+            resp.close = MagicMock()
+            # Both the submitted URL and the stored candidate URL resolve to ory.com
+            resp.url = 'https://www.ory.com/'
+            return resp
+
+        with patch('requests.get', side_effect=fake_get):
+            match_type, entry = cd.check_clouds_json_with_redirects(
+                'ory.com', 'Ory', 'https://www.ory.com/', clouds,
+            )
+        assert match_type == 'redirect_domain'
+        assert entry['name'] == 'Ory'
+
+    def test_fuzzy_name_stays_fuzzy_when_redirect_check_fails(self):
+        clouds = [{
+            "name": "Ory",
+            "url": "https://www.ory.sh/",
+            "description": "...",
+            "score": 3,
+            "categories": [],
+        }]
+        with patch('requests.get', side_effect=Exception('network down')):
+            match_type, entry = cd.check_clouds_json_with_redirects(
+                'ory.com', 'Ory', 'https://www.ory.com/', clouds,
+            )
+        assert match_type == 'fuzzy_name'
+        assert entry['name'] == 'Ory'
+
+    def test_no_name_match_upgraded_via_submitted_url_redirect(self):
+        # Submitted under a totally different name, but the URL redirects
+        # to an already-listed entry's domain.
+        def fake_get(url, **kwargs):
+            resp = MagicMock()
+            resp.close = MagicMock()
+            resp.url = 'https://www.ory.sh/'
+            return resp
+
+        with patch('requests.get', side_effect=fake_get):
+            match_type, entry = cd.check_clouds_json_with_redirects(
+                'rebranded-name.com', 'Totally New Brand', 'https://rebranded-name.com', self.ORY_CLOUDS,
+            )
+        assert match_type == 'redirect_domain'
+        assert entry['name'] == 'Different Name Entirely'
+
+    def test_no_match_stays_none_when_redirect_resolution_fails(self):
+        with patch('requests.get', side_effect=Exception('network down')):
+            result = cd.check_clouds_json_with_redirects(
+                'brandnew.io', 'Brand New Service', 'https://brandnew.io', self.ORY_CLOUDS,
+            )
+        assert result == (None, None)
+
+    def test_no_match_stays_none_when_no_redirect_happens(self):
+        def fake_get(url, **kwargs):
+            resp = MagicMock()
+            resp.close = MagicMock()
+            resp.url = url  # no redirect
+            return resp
+
+        with patch('requests.get', side_effect=fake_get):
+            result = cd.check_clouds_json_with_redirects(
+                'brandnew.io', 'Brand New Service', 'https://brandnew.io', self.ORY_CLOUDS,
+            )
+        assert result == (None, None)
+
 
 # ---------------------------------------------------------------------------
 # post_comment / add_label / close_issue
@@ -246,6 +408,15 @@ class TestBuildComment:
         comment = cd.build_comment('fuzzy_name', self.ENTRY)
         assert 'Closing' not in comment
 
+    def test_redirect_domain_comment_mentions_redirect(self):
+        comment = cd.build_comment('redirect_domain', self.ENTRY)
+        assert 'redirect' in comment.lower()
+        assert 'Fly.io' in comment
+
+    def test_redirect_domain_comment_does_not_mention_closing(self):
+        comment = cd.build_comment('redirect_domain', self.ENTRY)
+        assert 'Closing' not in comment
+
     def test_unknown_match_type_raises(self):
         with pytest.raises(ValueError):
             cd.build_comment('unknown_type', self.ENTRY)
@@ -270,8 +441,15 @@ class TestMain:
         }
     ]
 
-    def _run_main(self, env, clouds_json_content=None):
-        """Helper: run main() with patched env and clouds.json."""
+    def _run_main(self, env, clouds_json_content=None, resolve_final_domain=None):
+        """Helper: run main() with patched env and clouds.json.
+
+        By default `resolve_final_domain` is patched to always return '' (as
+        if every live redirect check failed/timed out), so existing tests
+        keep their pre-redirect-detection behaviour without hitting the
+        network. Pass a callable via `resolve_final_domain` to simulate
+        specific redirect outcomes.
+        """
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump(clouds_json_content or self.CLOUDS, f)
             clouds_path = f.name
@@ -282,6 +460,7 @@ class TestMain:
             output_lines.append(f'{key}={value}')
 
         no_op = MagicMock()
+        fake_resolve = resolve_final_domain or (lambda url, timeout=10: '')
 
         with patch.dict(os.environ, env, clear=True):
             with patch.object(cd, '_CLOUDS_JSON_PATH', clouds_path):
@@ -289,7 +468,8 @@ class TestMain:
                     with patch.object(cd, 'post_comment', no_op):
                         with patch.object(cd, 'add_label', no_op):
                             with patch.object(cd, 'close_issue', no_op):
-                                cd.main()
+                                with patch.object(cd, 'resolve_final_domain', side_effect=fake_resolve):
+                                    cd.main()
 
         os.unlink(clouds_path)
         return output_lines, no_op
@@ -367,9 +547,26 @@ class TestMain:
                     with patch.object(cd, 'post_comment', MagicMock()):
                         with patch.object(cd, 'add_label', MagicMock()):
                             with patch.object(cd, 'close_issue', close_mock):
-                                cd.main()
+                                with patch.object(cd, 'resolve_final_domain', return_value=''):
+                                    cd.main()
         os.unlink(clouds_path)
         close_mock.assert_not_called()
+
+    def test_redirect_domain_match_sets_is_duplicate_true_without_closing(self):
+        # Different name, but the submitted URL redirects to the listed domain.
+        env = {
+            'ISSUE_BODY': '**URL:** https://old-ory-domain.example',
+            'ISSUE_NUMBER': '50',
+            'ISSUE_TITLE': 'Totally Different Name',
+            'GH_TOKEN': 'token',
+            'REPO': 'owner/repo',
+        }
+        output_lines, mocks = self._run_main(
+            env,
+            resolve_final_domain=lambda url, timeout=10: 'fly.io',
+        )
+        assert any('is_duplicate=true' in line for line in output_lines)
+        assert any('duplicate_reason=redirect_domain' in line for line in output_lines)
 
     def test_clouds_json_read_failure_sets_is_duplicate_false(self):
         env = {


### PR DESCRIPTION
## Summary

Fixes the gap that let `ory.com` slip in as a "new" submission when `ory.sh` was already listed ([PR #302](https://github.com/datum-cloud/awesome-alt-clouds/pull/302)) — even though both submissions used the identical name "Ory", and `ory.sh` genuinely 301-redirects to `ory.com`.

Two independent fixes:

- **Short exact-name match**: fuzzy name matching required every token to be ≥4 chars, so short brand names like "Ory" (normalises to `"ory"`, 3 chars) were excluded from comparison entirely — even when submitted under the identical name. Added an exact-equality branch that fires regardless of length, ahead of the existing token-overlap logic (which is unchanged, so it still avoids the old "namecheap ⊇ heap" false-positive class).
- **Redirect-based domain detection**: new `resolve_final_domain()` follows HTTP redirects for a URL. Wired into `check_clouds_json_with_redirects()`, which does at most two targeted live requests per submission (never scans all entries):
  - If a fuzzy-name candidate is found, resolve both the submitted and candidate URLs — if they land on the same domain, that's a verified redirect duplicate.
  - If there's no name/domain match at all, resolve the submitted URL anyway and check its final domain against all (already-normalized, no-network) stored domains — catches a rebrand where the name changed but the old domain still forwards.

Redirect-confirmed matches (`redirect_domain`) are treated the same as today's `fuzzy_name` matches: comment + `duplicate` label, `is_duplicate=true` (blocks auto-evaluation), but **not** auto-closed — a human still confirms, since this is new logic and I'd rather it fail toward manual review than silently auto-close valid submissions.

## Test plan

- [x] Added unit tests for the short exact-name-match branch (`Ory` case + a negative case for distinct short names)
- [x] Added unit tests for `resolve_final_domain` (redirect / no-redirect / exception / timeout)
- [x] Added unit tests for `check_clouds_json_with_redirects` covering: exact-domain short-circuit (no network call), fuzzy-name upgrade to redirect_domain, fuzzy-name fallback when redirect check fails, no-match upgraded via submitted-URL redirect, no-match staying none
- [x] Added `build_comment` tests for the new `redirect_domain` case
- [x] Added a `main()` integration test confirming `redirect_domain` sets `is_duplicate=true`/`duplicate_reason=redirect_domain` without closing the issue
- [x] Full suite run: 55/56 pass; the 1 failure (`test_two_non_noise_words_concatenated`) is pre-existing on `main`, unrelated to this change (verified via `git stash`)