### PR TITLE
Automate graduation requests from Emerging & Unverified Providers

### DIFF
--- a/.github/workflows/approve-graduation.yml
+++ b/.github/workflows/approve-graduation.yml
@@ -1,0 +1,142 @@
+name: Approve Graduation
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  approve:
+    # Only run on issues (not PRs) with graduation-request label when a
+    # maintainer comments /approve-graduation (optionally with a category
+    # override: /approve-graduation Databases & Storage)
+    if: |
+      !github.event.issue.pull_request &&
+      contains(github.event.issue.labels.*.name, 'graduation-request') &&
+      startsWith(github.event.comment.body, '/approve-graduation')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Check if user is admin/maintainer
+        id: check-permission
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+
+            const allowed = ['admin', 'maintain', 'write'].includes(permission.permission);
+            console.log(`User ${context.actor} has ${permission.permission} permission. Allowed: ${allowed}`);
+
+            if (!allowed) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `❌ @${context.actor} You don't have permission to approve graduation requests.`
+              });
+              core.setOutput('allowed', 'false');
+            } else {
+              core.setOutput('allowed', 'true');
+            }
+
+      - name: Parse category override
+        if: steps.check-permission.outputs.allowed == 'true'
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = context.payload.comment.body.trim();
+            const rest = comment.replace(/^\/approve-graduation\s*/i, '').trim();
+            core.setOutput('category_override', rest);
+
+      - name: Checkout
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: steps.check-permission.outputs.allowed == 'true'
+        run: pip install requests beautifulsoup4 anthropic openai
+
+      - name: Re-evaluate with admin override
+        if: steps.check-permission.outputs.allowed == 'true'
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'claude' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          QWEN_BASE_URL: ${{ secrets.QWEN_BASE_URL }}
+          GRADUATION_ADMIN_APPROVED: 'true'
+          GRADUATION_CATEGORY_OVERRIDE: ${{ steps.parse.outputs.category_override }}
+        run: python scripts/evaluate_graduation.py
+
+      - name: Create graduation PR
+        if: steps.check-permission.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -f graduation_data.json ]; then
+            cat graduation_data.json
+            python scripts/create_graduation_pr.py
+          else
+            echo "ERROR: No graduation_data.json found — could not locate the entry to graduate"
+            cat graduation_results.md 2>/dev/null || true
+            exit 1
+          fi
+
+      - name: Update labels and comment
+        if: steps.check-permission.outputs.allowed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'graduation-ready'
+              });
+            } catch (e) {
+              // Label might not exist
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['approved']
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `✅ **Approved by @${context.actor}**\n\nA PR has been created to move this service to its new category.`
+            });

--- a/.github/workflows/audit-emerging-badges.yml
+++ b/.github/workflows/audit-emerging-badges.yml
@@ -1,0 +1,76 @@
+name: Audit Emerging Badges
+
+# Manual maintenance run: re-scores every entry in "Emerging & Unverified
+# Providers" and corrects its badge to match the real score. Not run on a
+# schedule or on push — every entry needs a live fetch + LLM call, so this
+# is triggered by a maintainer on demand.
+
+on:
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests beautifulsoup4 anthropic openai
+
+      - name: Run badge audit
+        env:
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'claude' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          QWEN_BASE_URL: ${{ secrets.QWEN_BASE_URL }}
+        run: python scripts/audit_emerging_badges.py
+
+      - name: Open PR if badges changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "No badge corrections needed."
+            exit 0
+          fi
+
+          branch_name="chore/emerging-badge-audit-$(date -u +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch_name"
+          git add README.md
+          git commit -m "chore: correct Emerging & Unverified Providers badges"
+          git push --force origin "$branch_name"
+
+          existing_pr=$(gh pr list --head "$branch_name" --state open --json number --jq ".[0].number" || true)
+          if [ -n "$existing_pr" ]; then
+            echo "PR #$existing_pr already exists for $branch_name, skipping creation"
+            exit 0
+          fi
+
+          gh pr create \
+            --title "chore: correct Emerging & Unverified Providers badges" \
+            --body-file audit_report.md \
+            --base main \
+            --head "$branch_name"

--- a/.github/workflows/graduation-request.yml
+++ b/.github/workflows/graduation-request.yml
@@ -1,0 +1,78 @@
+name: Graduation Request
+
+# Trigger: the Alt Cloud browser extension opens a "[Graduation] <Service>"
+# issue asking the bot to re-check a service currently listed under
+# "Emerging & Unverified Providers" and move it into its real category if
+# it now clears the 2/3 bar. This only posts a fresh evaluation comment —
+# the actual README move requires a maintainer to comment
+# /approve-graduation (see approve-graduation.yml).
+
+on:
+  issues:
+    types: [opened]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  evaluate:
+    if: contains(github.event.issue.title, '[Graduation')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests beautifulsoup4 anthropic openai
+
+      - name: Re-evaluate service
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'claude' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          QWEN_BASE_URL: ${{ secrets.QWEN_BASE_URL }}
+        run: python scripts/evaluate_graduation.py
+
+      - name: Post evaluation results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('graduation_results.md', 'utf8');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: results
+            });
+
+      - name: Add labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const score = parseInt(fs.readFileSync('graduation_score.txt', 'utf8').trim());
+
+            const labels = ['graduation-request'];
+            if (score >= 2) {
+              labels.push('graduation-ready');
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels,
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,27 @@ Bullet is `*` (not `-`); badge is required; separator is exactly `-`; alphabetic
 
 `WATCHLIST.md` tracks 1-of-3-criteria candidates submitted 2+ times. `scripts/generate_watchlist_json.py` turns it into `public/watchlist.json`, rendered at `/watchlist/`.
 
+### Graduation pipeline (moving out of "Emerging & Unverified Providers")
+
+`"Emerging & Unverified Providers"` is a normal entry in `evaluate_submission.py:CATEGORIES` — its entries are published (unlike Watchlist rows) but flagged as needing verification. The graduation flow re-checks one of these entries and, if it now qualifies, moves it into a real category:
+
+```
+"[Graduation] <Name>" issue (from the browser extension, or opened manually)
+  → graduation-request.yml → evaluate_graduation.py
+     (locates the existing README.md entry by name, re-runs the same
+     evaluate_service()/generate_metadata() cascade against its URL)
+  → comments a fresh score; labels graduation-request (+ graduation-ready if >=2/3)
+  → maintainer comments /approve-graduation [Category Name] on the issue
+  → approve-graduation.yml re-runs evaluate_graduation.py in admin mode
+     → create_graduation_pr.py (removes the old bullet, inserts the
+       corrected one into the target category) → PR for review
+```
+
+- Shares `evaluate_service()`/`generate_metadata()` with the submission pipeline (`scripts/evaluate_submission.py`) — don't duplicate the fetch/scoring logic.
+- README bullet add/remove/lookup helpers live in `scripts/lib/readme_entries.py`, shared by `create_submission_pr.py` and `create_graduation_pr.py`.
+- Nothing writes to README.md without an explicit maintainer command (`/approve-graduation`), matching the submission pipeline's `/approve` gate — the initial issue-open evaluation only comments.
+- `scripts/audit_emerging_badges.py` (via the `Audit Emerging Badges` workflow, `workflow_dispatch` only) is a one-off maintenance job that re-scores every Emerging entry and corrects its badge; it flags but never removes entries scoring below 2/3.
+
 ## Notes on stale docs
 
 - `.cursor/rules/docs-frontend.mdc` describes a legacy vanilla-JS `docs/` SPA (dependency-free static site, `docs/index.html` + `docs/submit/index.html`). That folder has since been removed from this branch as part of the Astro migration cutover (see `analysis/2026-07-20-phase-6-production-cutover-checklist.md`); the Astro site under `src/` is now the only frontend, and `public/clouds.json`/`public/llms*.txt` replace the old `docs/` equivalents. Ignore that rule file's specifics; its regex/anti-spam/SEO cautions about the _submission form_ still apply conceptually to `src/pages/submit/index.astro`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ If your service lands on the watchlist, the "Criteria Needed" column shows exact
 
 The public watchlist page lives at `/watchlist/` and is generated from `WATCHLIST.md` on every deploy.
 
+### Graduating an "Emerging & Unverified Providers" listing
+
+Some services are listed under [Emerging & Unverified Providers](README.md#emerging--unverified-providers) — they're in the directory, but flagged as needing verification (usually pricing or self-service details the bot couldn't confirm). Unlike the Watchlist, these entries are already published.
+
+To request a re-check, open an issue titled `[Graduation] <Service Name>` (the Alt Cloud browser extension does this for you) — the bot re-runs the 3-criteria evaluation against the current listing and comments the result. If it now scores 2/3 or higher and the bot has a better-fitting category, a maintainer confirms with `/approve-graduation` (or `/approve-graduation <Category Name>` to pick the category) to open a PR moving the entry out of Emerging & Unverified Providers.
+
 ## 2. Working on the website
 
 The site is an [Astro](https://astro.build) static site with Tailwind CSS v4, hosted on GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ Services that show promise but don't yet fully meet Alt Cloud criteria (public p
 
 Why track these? The cloud landscape changes fast. Today's "contact sales only" can become tomorrow's self-service leader. This section helps monitor emerging players and hold established vendors accountable to transparency.
 
+Think one of these now qualifies? Open an issue titled `[Graduation] <Name>` (or use the browser extension) — see [CONTRIBUTING.md](CONTRIBUTING.md#graduating-an-emerging--unverified-providers-listing) for how the re-verification works.
+
 * 🟢 [API7](https://api7.ai/) - Commercial distribution of Apache APISIX with cloud offerings, pending pricing transparency verification.
 * 🟢 [Apigee](https://cloud.google.com/apigee) - Google's API management platform with advanced features but enterprise-only pricing model.
 * 🟢 [Chroma](https://www.trychroma.com/) - Open-source vector database, managed cloud service details need verification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ select = ["E", "F", "I", "W", "UP"]
 # Long issue-comment templates and README insert blocks
 "scripts/create_submission_pr.py" = ["E501"]
 "scripts/evaluate_submission.py" = ["E501"]
+"scripts/create_graduation_pr.py" = ["E501"]
+"scripts/evaluate_graduation.py" = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/audit_emerging_badges.py
+++ b/scripts/audit_emerging_badges.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""One-off maintenance: re-score every Emerging & Unverified Providers entry
+and correct its badge to match.
+
+Every entry in this README section currently shows a green (3/3) badge
+regardless of its actual score, which contradicts both the badge legend
+and the section's own "doesn't yet fully meet criteria" description. This
+re-runs the same 3-criteria evaluation the submission pipeline uses and
+fixes each badge in place.
+
+Meant to run via the `audit-emerging-badges` workflow_dispatch workflow,
+since it needs live network + LLM credentials — not on every push.
+
+Never removes entries, even ones scoring below the 2/3 publish bar; that
+call needs a maintainer, so sub-2/3 entries are flagged in the report
+instead of touched.
+
+Writes:
+  README.md       - badges corrected in place (only if something changed)
+  audit_report.md - summary of corrections and entries flagged for review
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from evaluate_submission import evaluate_service  # noqa: E402
+from lib.readme_entries import badge_for_score, list_entries_in_category  # noqa: E402
+
+EMERGING_CATEGORY = "Emerging & Unverified Providers"
+README_FILE = "README.md"
+
+
+def audit(content):
+    """Re-score every entry in EMERGING_CATEGORY. Returns (new_content, changed, flagged)."""
+    entries = list_entries_in_category(content, EMERGING_CATEGORY)
+    lines = content.split("\n")
+    changed = []
+    flagged = []
+
+    for entry in entries:
+        print(f"Evaluating {entry['name']} ({entry['url']})...")
+        result = evaluate_service(entry["url"])
+        score = result["score"]
+        new_badge = badge_for_score(score)
+
+        if score < 2:
+            flagged.append({**entry, "score": score})
+
+        if new_badge != entry["badge"]:
+            lines[entry["line_idx"]] = lines[entry["line_idx"]].replace(
+                entry["badge"], new_badge, 1
+            )
+            changed.append({**entry, "score": score, "new_badge": new_badge})
+
+    return "\n".join(lines), changed, flagged, len(entries)
+
+
+def build_report(total, changed, flagged):
+    report = [f"## {EMERGING_CATEGORY} badge audit\n", f"Re-evaluated {total} entries.\n"]
+
+    if changed:
+        report.append("### Badges corrected\n")
+        report.append("| Name | Old | New | Score |\n|------|-----|-----|-------|\n")
+        for c in changed:
+            report.append(f"| {c['name']} | {c['badge']} | {c['new_badge']} | {c['score']}/3 |\n")
+    else:
+        report.append("No badge corrections needed.\n")
+
+    if flagged:
+        report.append(
+            "\n### Needs manual review (scored below 2/3 — may not belong in the public list)\n"
+        )
+        report.append("| Name | URL | Score |\n|------|-----|-------|\n")
+        for f in flagged:
+            report.append(f"| {f['name']} | {f['url']} | {f['score']}/3 |\n")
+
+    return "\n".join(report)
+
+
+def main():
+    with open(README_FILE) as f:
+        content = f.read()
+
+    new_content, changed, flagged, total = audit(content)
+
+    if total == 0:
+        print(f"No entries found in '{EMERGING_CATEGORY}'")
+        with open("audit_report.md", "w") as f:
+            f.write(f"No entries found in **{EMERGING_CATEGORY}** — nothing to audit.\n")
+        return
+
+    if changed:
+        with open(README_FILE, "w") as f:
+            f.write(new_content)
+
+    with open("audit_report.md", "w") as f:
+        f.write(build_report(total, changed, flagged))
+
+    print(f"Corrected {len(changed)} badge(s), flagged {len(flagged)} entrie(s) for review")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_graduation_pr.py
+++ b/scripts/create_graduation_pr.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Create a PR that moves a graduated service to its real category.
+
+Reads graduation_data.json (written by evaluate_graduation.py) and opens a
+PR that removes the entry from its current "Emerging & Unverified
+Providers" bullet and re-inserts it, alphabetically, into the category it
+now qualifies for.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from lib.readme_entries import (  # noqa: E402
+    add_entry_to_readme,
+    badge_for_score,
+    find_entry_by_name,
+    remove_entry_from_readme,
+)
+from lib.shell import run_command  # noqa: E402
+from lib.slugify import slugify  # noqa: E402
+
+README_FILE = "README.md"
+
+
+def load_graduation_data():
+    with open("graduation_data.json") as f:
+        return json.load(f)
+
+
+def move_entry_in_readme(data):
+    """Remove the old bullet and insert the corrected one. Returns True on success."""
+    with open(README_FILE) as f:
+        content = f.read()
+
+    entry = find_entry_by_name(content, data["name"])
+    if entry is None:
+        print(f"Warning: '{data['name']}' not found in README, nothing to graduate")
+        return False
+
+    if entry["category"] != data["old_category"]:
+        print(
+            f"Warning: '{data['name']}' is now in '{entry['category']}', "
+            f"not '{data['old_category']}' — README changed since evaluation, skipping"
+        )
+        return False
+
+    content = remove_entry_from_readme(content, entry["line_idx"])
+
+    submission = {
+        "name": data["name"],
+        "url": data["url"],
+        "category": data["new_category"],
+        "score": data["score"],
+        "description": data["description"],
+    }
+    new_content = add_entry_to_readme(submission, content=content)
+    if new_content is None:
+        print(f"Warning: target category '{data['new_category']}' not found in README")
+        return False
+
+    with open(README_FILE, "w") as f:
+        f.write(new_content)
+
+    return True
+
+
+def create_pr(data):
+    name = data["name"]
+    issue_number = data.get("issue_number", "unknown")
+    branch_name = f"graduation-{issue_number}-{slugify(name)[:30]}"
+
+    run_command('git config user.name "github-actions[bot]"')
+    run_command('git config user.email "github-actions[bot]@users.noreply.github.com"')
+    run_command(f"git checkout -b {branch_name}")
+
+    if not move_entry_in_readme(data):
+        return False
+
+    run_command("git add README.md")
+
+    commit_msg = (
+        f"Graduate {name} from {data['old_category']} to {data['new_category']}"
+        f"\\n\\nCloses #{issue_number}"
+    )
+    run_command(f'git commit -m "{commit_msg}"')
+    run_command(f"git push --force origin {branch_name}")
+
+    existing_pr = run_command(
+        f'gh pr list --head {branch_name} --state open --json number --jq ".[0].number"',
+        check=False,
+    )
+    if existing_pr.strip():
+        print(
+            f"PR #{existing_pr.strip()} already exists for branch {branch_name}, skipping creation"
+        )
+        return True
+
+    badge = badge_for_score(data["score"])
+    pr_title = f"Graduate {badge} {name} from {data['old_category']} to {data['new_category']}"
+
+    review_note = " ⚠️ needs verification" if data.get("needs_manual_review") else ""
+    pr_body = f"""## Graduation Request
+
+This PR moves **{name}** from **{data["old_category"]}** to **{data["new_category"]}**.
+
+| Field | Value |
+|-------|-------|
+| Name | {name} |
+| URL | {data["url"]} |
+| From | {data["old_category"]} |
+| To | {data["new_category"]} |
+| Score | {data["score"]}/3 {badge}{review_note} |
+| Description | {data["description"]} |
+
+If a `src/content/clouds/` profile exists for this service, its `category`
+frontmatter may need a follow-up update to match — this bot only edits
+README.md.
+
+Closes #{issue_number}
+
+*This PR was automatically created by the graduation-request bot.*
+"""
+
+    pr_body_escaped = pr_body.replace('"', '\\"').replace("`", "\\`")
+    result = run_command(
+        f'gh pr create --title "{pr_title}" --body "{pr_body_escaped}" --base main --head {branch_name}'
+    )
+    print(f"PR creation result: {result}")
+    return True
+
+
+def main():
+    try:
+        data = load_graduation_data()
+    except FileNotFoundError:
+        print("No graduation_data.json found, skipping PR creation")
+        return 0
+
+    print(
+        f"Creating graduation PR for {data['name']} ({data['old_category']} -> {data['new_category']})"
+    )
+
+    try:
+        create_pr(data)
+        print("PR created successfully!")
+        return 0
+    except Exception as e:
+        print(f"Error creating PR: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/create_submission_pr.py
+++ b/scripts/create_submission_pr.py
@@ -8,123 +8,27 @@ that adds the service to the appropriate category in README.md.
 
 import json
 import os
-import re
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+from lib.readme_entries import add_entry_to_readme  # noqa: E402
+from lib.shell import run_command  # noqa: E402
 from lib.slugify import slugify  # noqa: E402
-
-
-def run_command(cmd, check=True):
-    """Run a shell command and return output"""
-    print(f"Running: {cmd}")
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-    if check and result.returncode != 0:
-        print(f"Error: {result.stderr}")
-        raise Exception(f"Command failed: {cmd}")
-    return result.stdout.strip()
 
 
 def load_submission_data():
     """Load submission data from JSON file"""
-    with open('submission_data.json', 'r') as f:
+    with open("submission_data.json") as f:
         data = json.load(f)
 
     # Handle both old single-service format and new multi-service format
-    if 'services' in data:
+    if "services" in data:
         return data
     else:
         # Convert old format to new format
-        return {
-            'services': [data],
-            'issue_number': data.get('issue_number', 'unknown')
-        }
-
-
-def find_category_section(readme_content, category):
-    """Find the start and end of a category section in README"""
-    lines = readme_content.split('\n')
-
-    # Find the category header
-    category_header = f"## {category}"
-    start_idx = None
-    end_idx = None
-
-    for i, line in enumerate(lines):
-        if line.strip() == category_header:
-            start_idx = i
-        elif start_idx is not None and line.startswith('## ') and i > start_idx:
-            end_idx = i
-            break
-
-    if start_idx is None:
-        return None, None
-
-    # If no next section found, go to end of file
-    if end_idx is None:
-        end_idx = len(lines)
-
-    return start_idx, end_idx
-
-
-def add_entry_to_readme(submission):
-    """Add the submission entry to README.md in the correct category"""
-    with open('README.md', 'r') as f:
-        content = f.read()
-
-    category = submission['category']
-    start_idx, end_idx = find_category_section(content, category)
-
-    if start_idx is None:
-        print(f"Warning: Category '{category}' not found in README")
-        return False
-
-    lines = content.split('\n')
-
-    # Determine badge based on score
-    badge = '🟢' if submission['score'] == 3 else '🟡'
-
-    # Create the new entry
-    new_entry = f"* {badge} [{submission['name']}]({submission['url']}) - {submission['description']}"
-
-    # Find all entries in this section (lines starting with "* ")
-    entries = []
-    insert_after_idx = start_idx
-
-    for i in range(start_idx + 1, end_idx):
-        line = lines[i].strip()
-        if line.startswith('* '):
-            entries.append((i, line))
-            insert_after_idx = i
-
-    # Find alphabetical position for new entry
-    # Extract name for sorting (case-insensitive)
-    new_name = submission['name'].lower()
-
-    insert_idx = None
-    for i, (line_idx, line) in enumerate(entries):
-        # Extract name from entry: * 🟢 [Name](url) - desc
-        match = re.search(r'\[([^\]]+)\]', line)
-        if match:
-            entry_name = match.group(1).lower()
-            if new_name < entry_name:
-                insert_idx = line_idx
-                break
-
-    # If not found, insert at end of section
-    if insert_idx is None:
-        insert_idx = insert_after_idx + 1
-
-    # Insert the new entry
-    lines.insert(insert_idx, new_entry)
-
-    # Write back
-    with open('README.md', 'w') as f:
-        f.write('\n'.join(lines))
-
-    return True
+        return {"services": [data], "issue_number": data.get("issue_number", "unknown")}
 
 
 def generate_and_stage_mdx(service):
@@ -150,15 +54,17 @@ def generate_and_stage_mdx(service):
         categories = [service.get("category", "")] if service.get("category") else []
 
     env = os.environ.copy()
-    env.update({
-        "CLOUD_NAME": name,
-        "CLOUD_URL": service.get("url", ""),
-        "CLOUD_SCORE": str(service.get("score", 3)),
-        "CLOUD_CATEGORIES": ",".join(c for c in categories if c),
-        "CLOUD_DESCRIPTION": service.get("description", ""),
-        "OUTPUT_PATH": output_path,
-        "DRY_RUN": "false",
-    })
+    env.update(
+        {
+            "CLOUD_NAME": name,
+            "CLOUD_URL": service.get("url", ""),
+            "CLOUD_SCORE": str(service.get("score", 3)),
+            "CLOUD_CATEGORIES": ",".join(c for c in categories if c),
+            "CLOUD_DESCRIPTION": service.get("description", ""),
+            "OUTPUT_PATH": output_path,
+            "DRY_RUN": "false",
+        }
+    )
 
     generator = os.path.join(os.path.dirname(__file__), "generate_cloud_profile.py")
     result = subprocess.run(
@@ -192,8 +98,8 @@ def generate_and_stage_mdx(service):
 
 def create_pr(data):
     """Create a branch and PR for the submission(s)"""
-    services = data['services']
-    issue_number = data.get('issue_number', 'unknown')
+    services = data["services"]
+    issue_number = data.get("issue_number", "unknown")
 
     if not services:
         print("No services to add")
@@ -201,7 +107,9 @@ def create_pr(data):
 
     # Create branch name
     if len(services) == 1:
-        branch_name = f"submission-{issue_number}-{services[0]['name'].lower().replace(' ', '-')[:30]}"
+        branch_name = (
+            f"submission-{issue_number}-{services[0]['name'].lower().replace(' ', '-')[:30]}"
+        )
     else:
         branch_name = f"submission-{issue_number}-{len(services)}-services"
 
@@ -210,7 +118,7 @@ def create_pr(data):
     run_command('git config user.email "github-actions[bot]@users.noreply.github.com"')
 
     # Create and checkout new branch
-    run_command(f'git checkout -b {branch_name}')
+    run_command(f"git checkout -b {branch_name}")
 
     # Add each entry to README
     added_services = []
@@ -233,42 +141,44 @@ def create_pr(data):
             mdx_reports.append(report)
 
     # Commit changes
-    run_command('git add README.md')
+    run_command("git add README.md")
 
     if len(added_services) == 1:
         s = added_services[0]
         commit_msg = f"Add {s['name']} to {s['category']}\\n\\nCloses #{issue_number}"
     else:
-        names = ', '.join(s['name'] for s in added_services)
+        names = ", ".join(s["name"] for s in added_services)
         commit_msg = f"Add {len(added_services)} services: {names}\\n\\nCloses #{issue_number}"
 
     run_command(f'git commit -m "{commit_msg}"')
 
     # Push branch (force in case a previous run already pushed this branch)
-    run_command(f'git push --force origin {branch_name}')
+    run_command(f"git push --force origin {branch_name}")
 
     # Skip PR creation if one already exists for this branch
     existing_pr = run_command(
         f'gh pr list --head {branch_name} --state open --json number --jq ".[0].number"',
-        check=False
+        check=False,
     )
     if existing_pr.strip():
-        print(f"PR #{existing_pr.strip()} already exists for branch {branch_name}, skipping creation")
+        print(
+            f"PR #{existing_pr.strip()} already exists for branch {branch_name}, skipping creation"
+        )
         return True
 
     # Create PR
     if len(added_services) == 1:
         s = added_services[0]
-        badge = '🟢' if s['score'] == 3 else '🟡'
+        badge = "🟢" if s["score"] == 3 else "🟡"
         pr_title = f"Add {badge} {s['name']} to {s['category']}"
     else:
         pr_title = f"Add {len(added_services)} new cloud services"
 
     # Check if any services need manual review
-    needs_review = [s for s in added_services if s.get('needs_manual_review')]
+    needs_review = [s for s in added_services if s.get("needs_manual_review")]
 
     # Build PR body
-    pr_body = f"""## New Cloud Service Submission
+    pr_body = """## New Cloud Service Submission
 
 """
 
@@ -285,25 +195,25 @@ Please manually verify the 3 criteria before merging:
 
     if len(added_services) == 1:
         s = added_services[0]
-        badge = '🟢' if s['score'] == 3 else '🟡'
-        review_note = " ⚠️ needs verification" if s.get('needs_manual_review') else ""
-        pr_body += f"""This PR adds **{s['name']}** to the **{s['category']}** category.
+        badge = "🟢" if s["score"] == 3 else "🟡"
+        review_note = " ⚠️ needs verification" if s.get("needs_manual_review") else ""
+        pr_body += f"""This PR adds **{s["name"]}** to the **{s["category"]}** category.
 
 | Field | Value |
 |-------|-------|
-| Name | {s['name']} |
-| URL | {s['url']} |
-| Category | {s['category']} |
-| Score | {s['score']}/3 {badge}{review_note} |
-| Description | {s['description']} |
+| Name | {s["name"]} |
+| URL | {s["url"]} |
+| Category | {s["category"]} |
+| Score | {s["score"]}/3 {badge}{review_note} |
+| Description | {s["description"]} |
 """
     else:
         pr_body += f"This PR adds **{len(added_services)} services**:\n\n"
         pr_body += "| Name | Category | Score | URL | Status |\n"
         pr_body += "|------|----------|-------|-----|--------|\n"
         for s in added_services:
-            badge = '🟢' if s['score'] == 3 else '🟡'
-            status = "⚠️ Needs verification" if s.get('needs_manual_review') else "✅ Verified"
+            badge = "🟢" if s["score"] == 3 else "🟡"
+            status = "⚠️ Needs verification" if s.get("needs_manual_review") else "✅ Verified"
             pr_body += f"| {s['name']} | {s['category']} | {s['score']}/3 {badge} | {s['url']} | {status} |\n"
 
     if mdx_reports:
@@ -311,7 +221,9 @@ Please manually verify the 3 criteria before merging:
         pr_body += "Each service below also has a `status: draft` MDX profile staged in this PR. "
         pr_body += "Draft profiles are only built on preview deploys; they ship to production after a maintainer flips `status: reviewed`.\n\n"
         for r in mdx_reports:
-            flag = " (needs verification — WebSearch fallback)" if r.get("needs_verification") else ""
+            flag = (
+                " (needs verification — WebSearch fallback)" if r.get("needs_verification") else ""
+            )
             pr_body += f"- `{r['output_path']}`{flag}\n"
 
     pr_body += f"""
@@ -327,7 +239,7 @@ Closes #{issue_number}
     # "Allow GitHub Actions to create and approve pull requests" setting being off —
     # raises, prints stderr, and fails the workflow step instead of silently no-opping
     # after the branch has already been pushed.
-    pr_body_escaped = pr_body.replace('"', '\\"').replace('`', '\\`')
+    pr_body_escaped = pr_body.replace('"', '\\"').replace("`", "\\`")
     result = run_command(
         f'gh pr create --title "{pr_title}" --body "{pr_body_escaped}" --base main --head {branch_name}'
     )
@@ -344,7 +256,7 @@ def main():
         print("No submission_data.json found, skipping PR creation")
         return 0
 
-    services = data.get('services', [])
+    services = data.get("services", [])
     if not services:
         print("No services to add")
         return 0

--- a/scripts/evaluate_graduation.py
+++ b/scripts/evaluate_graduation.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Re-evaluate a [Graduation] request against its current README.md entry.
+
+A graduation request asks the bot to re-check a service that's currently
+listed under "Emerging & Unverified Providers" and, if it now clears the
+bar, move it into its real category. Unlike a fresh submission, the URL and
+current category come from the existing README.md entry, not the issue
+body — the issue only tells us *which* entry to re-check.
+
+Reads from the environment:
+  ISSUE_BODY, ISSUE_TITLE, ISSUE_NUMBER  - required
+  LLM_PROVIDER, ANTHROPIC_API_KEY, QWEN_BASE_URL - passed through to the
+    shared evaluate_submission fetch/metadata cascade
+  GRADUATION_ADMIN_APPROVED - 'true' when a maintainer ran /approve-graduation;
+    bypasses the 2/3 gate so graduation_data.json is always written
+  GRADUATION_CATEGORY_OVERRIDE - maintainer-specified target category,
+    overrides whatever category the LLM suggests
+
+Writes:
+  graduation_results.md - markdown comment for the issue
+  graduation_score.txt  - fresh score (0-3), or '0' if the entry couldn't
+    be located at all
+  graduation_data.json  - present only when the request is ready to move
+    (score >= 2, or admin-approved)
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from evaluate_submission import (  # noqa: E402
+    CATEGORIES,
+    evaluate_service,
+    generate_metadata,
+    generate_single_result_markdown,
+)
+from lib.readme_entries import find_entry_by_name  # noqa: E402
+
+EMERGING_CATEGORY = "Emerging & Unverified Providers"
+
+
+def extract_service_name(title, body):
+    """Determine which service this graduation request is about.
+
+    Prefers the **Service:** markdown link the browser extension writes into
+    the body (ground truth for the name as it appears on the site); falls
+    back to the issue title (strip a leading "[Graduation]"/"[Graduation
+    Request]" tag) if that field is missing or malformed.
+    """
+    match = re.search(r"\*\*Service:\*\*\s*\[([^\]]+)\]\(([^)]+)\)", body)
+    if match:
+        return match.group(1).strip()
+
+    title_match = re.match(r"^\[Graduation(?:\s+Request)?\]\s*(.+)", title, re.IGNORECASE)
+    if title_match:
+        return title_match.group(1).strip()
+
+    return None
+
+
+def write_error(message):
+    with open("graduation_results.md", "w") as f:
+        f.write(f"## Graduation Request\n\n:warning: {message}\n")
+    with open("graduation_score.txt", "w") as f:
+        f.write("0")
+
+
+def build_comment(name, old_category, result, ai_metadata, new_category):
+    score = result["score"]
+    header = f"## Graduation Request: {name}\n\nRe-evaluating the current **{old_category}** entry against the 3 criteria.\n\n"
+    body = generate_single_result_markdown(result, ai_metadata)
+
+    if ai_metadata and new_category and new_category != old_category and score >= 2:
+        next_steps = (
+            f"\n:rocket: This looks ready to graduate from **{old_category}** to **{new_category}**. "
+            "A maintainer can comment `/approve-graduation` (or `/approve-graduation <Category Name>` "
+            "to pick a different category) to open the move PR.\n"
+        )
+    elif ai_metadata and score >= 2:
+        next_steps = (
+            f"\nThis service now scores {score}/3, but **{old_category}** still looks like its best fit — "
+            "there may not be a clearer category yet. A maintainer can force one with "
+            "`/approve-graduation <Category Name>` if appropriate.\n"
+        )
+    else:
+        next_steps = (
+            f"\nStill doesn't meet the bar for graduation (needs 2/3). It stays in **{old_category}** "
+            "until re-evaluated with new evidence.\n"
+        )
+
+    return header + body + next_steps
+
+
+def main():
+    issue_body = os.environ.get("ISSUE_BODY", "")
+    issue_title = os.environ.get("ISSUE_TITLE", "")
+    admin_approved = os.environ.get("GRADUATION_ADMIN_APPROVED", "").lower() == "true"
+    category_override = os.environ.get("GRADUATION_CATEGORY_OVERRIDE", "").strip()
+
+    if not issue_body or not issue_title:
+        print("Error: ISSUE_BODY / ISSUE_TITLE environment variables not set")
+        sys.exit(1)
+
+    name = extract_service_name(issue_title, issue_body)
+    if not name:
+        write_error(
+            "Could not determine which service this graduation request is about "
+            "(no `**Service:**` field in the body and no name after the `[Graduation]` title tag)."
+        )
+        return
+
+    with open("README.md") as f:
+        readme_content = f.read()
+
+    entry = find_entry_by_name(readme_content, name)
+    if entry is None:
+        write_error(
+            f"Could not find an existing README.md entry named **{name}**. "
+            "Graduation requests re-evaluate a service that's already listed — "
+            "use the submission form for new services."
+        )
+        return
+
+    if entry["category"] != EMERGING_CATEGORY:
+        write_error(
+            f"**{name}** is already listed under **{entry['category']}**, not {EMERGING_CATEGORY} — "
+            "nothing to graduate."
+        )
+        return
+
+    print(f"Re-evaluating {name} ({entry['url']}), currently in {entry['category']}")
+    result = evaluate_service(entry["url"])
+    score = result["score"]
+
+    ai_metadata = result.get("ai_metadata")
+    if not ai_metadata:
+        ai_metadata = generate_metadata(entry["url"], result.get("page_content", ""))
+        if ai_metadata:
+            result["ai_metadata"] = ai_metadata
+
+    new_category = None
+    if category_override:
+        new_category = category_override
+    elif ai_metadata:
+        new_category = ai_metadata.get("category")
+
+    if new_category and new_category not in CATEGORIES:
+        print(f"Warning: '{new_category}' is not a known category, ignoring override")
+        new_category = ai_metadata.get("category") if ai_metadata else None
+
+    comment = build_comment(name, entry["category"], result, ai_metadata, new_category)
+    with open("graduation_results.md", "w") as f:
+        f.write(comment)
+    with open("graduation_score.txt", "w") as f:
+        f.write(str(score))
+
+    ready = admin_approved or score >= 2
+    if ready and new_category:
+        description = (
+            ai_metadata.get("description", entry["description"])
+            if ai_metadata
+            else entry["description"]
+        )
+        graduation_data = {
+            "issue_number": os.environ.get("ISSUE_NUMBER", "unknown"),
+            "name": name,
+            "url": entry["url"],
+            "old_category": entry["category"],
+            "new_category": new_category,
+            "score": score if not admin_approved else max(score, 2),
+            "description": description,
+            "needs_manual_review": result.get("needs_manual_review", False),
+        }
+        with open("graduation_data.json", "w") as f:
+            json.dump(graduation_data, f, indent=2)
+        print(f"Graduation data saved: {name} -> {new_category}")
+    else:
+        print(f"Not ready to graduate ({score}/3, category={new_category})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/readme_entries.py
+++ b/scripts/lib/readme_entries.py
@@ -1,0 +1,163 @@
+"""Shared README.md category-section helpers.
+
+Used by create_submission_pr.py (add a new service) and
+create_graduation_pr.py (move an existing service between categories).
+Both read/write the same `* <badge> [Name](url) - description` bullet
+format documented in CLAUDE.md.
+"""
+
+import re
+
+README_FILE = "README.md"
+
+
+def find_category_section(readme_content, category):
+    """Return (start_idx, end_idx) line range of a `## <category>` section."""
+    lines = readme_content.split("\n")
+
+    category_header = f"## {category}"
+    start_idx = None
+    end_idx = None
+
+    for i, line in enumerate(lines):
+        if line.strip() == category_header:
+            start_idx = i
+        elif start_idx is not None and line.startswith("## ") and i > start_idx:
+            end_idx = i
+            break
+
+    if start_idx is None:
+        return None, None
+
+    if end_idx is None:
+        end_idx = len(lines)
+
+    return start_idx, end_idx
+
+
+def badge_for_score(score):
+    """3/3 -> green, 2/3 -> yellow. Matches the README legend."""
+    return "🟢" if score == 3 else "🟡"
+
+
+def add_entry_to_readme(submission, content=None):
+    """Insert `submission` into its category section, alphabetically by name.
+
+    Reads/writes README.md unless `content` is passed (then returns the new
+    content instead of writing, letting callers batch a remove+add together).
+    Returns None if the category section can't be found.
+    """
+    own_content = content is None
+    if own_content:
+        with open(README_FILE) as f:
+            content = f.read()
+
+    category = submission["category"]
+    start_idx, end_idx = find_category_section(content, category)
+
+    if start_idx is None:
+        print(f"Warning: Category '{category}' not found in README")
+        return None
+
+    lines = content.split("\n")
+    badge = badge_for_score(submission["score"])
+    new_entry = (
+        f"* {badge} [{submission['name']}]({submission['url']}) - {submission['description']}"
+    )
+
+    entries = []
+    insert_after_idx = start_idx
+
+    for i in range(start_idx + 1, end_idx):
+        line = lines[i].strip()
+        if line.startswith("* "):
+            entries.append((i, line))
+            insert_after_idx = i
+
+    new_name = submission["name"].lower()
+    insert_idx = None
+    for line_idx, line in entries:
+        match = re.search(r"\[([^\]]+)\]", line)
+        if match and new_name < match.group(1).lower():
+            insert_idx = line_idx
+            break
+
+    if insert_idx is None:
+        insert_idx = insert_after_idx + 1
+
+    lines.insert(insert_idx, new_entry)
+    new_content = "\n".join(lines)
+
+    if own_content:
+        with open(README_FILE, "w") as f:
+            f.write(new_content)
+        return True
+
+    return new_content
+
+
+def _parse_bullet_line(line):
+    """Parse `* <badge> [Name](url) - description`, or return None."""
+    match = re.match(r"\*\s*(\S+)\s*\[([^\]]+)\]\(([^)]+)\)\s*-\s*(.+)", line.strip())
+    if not match:
+        return None
+    return {
+        "badge": match.group(1),
+        "name": match.group(2).strip(),
+        "url": match.group(3),
+        "description": match.group(4),
+    }
+
+
+def find_entry_by_name(readme_content, name):
+    """Find an existing `* <badge> [Name](url) - description` bullet by name.
+
+    Name matching is case-insensitive and exact (not substring), since
+    category names commonly overlap (e.g. "Split" vs "Splitwise"). Returns
+    a dict with category/url/description/badge/line_idx, or None if no
+    entry matches.
+    """
+    lines = readme_content.split("\n")
+    target = name.strip().lower()
+
+    current_category = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            current_category = stripped[3:].strip()
+            continue
+
+        parsed = _parse_bullet_line(stripped)
+        if not parsed or parsed["name"].lower() != target:
+            continue
+
+        return {"line_idx": i, "category": current_category, **parsed}
+
+    return None
+
+
+def list_entries_in_category(readme_content, category):
+    """Return every bullet entry within a `## <category>` section.
+
+    Each item is a dict with line_idx/badge/name/url/description, in the
+    order they appear in the file.
+    """
+    lines = readme_content.split("\n")
+    start_idx, end_idx = find_category_section(readme_content, category)
+    if start_idx is None:
+        return []
+
+    entries = []
+    for i in range(start_idx + 1, end_idx):
+        parsed = _parse_bullet_line(lines[i])
+        if parsed:
+            entries.append({"line_idx": i, **parsed})
+
+    return entries
+
+
+def remove_entry_from_readme(readme_content, line_idx):
+    """Remove the bullet at `line_idx` and return the new content."""
+    lines = readme_content.split("\n")
+    del lines[line_idx]
+    return "\n".join(lines)

--- a/scripts/lib/shell.py
+++ b/scripts/lib/shell.py
@@ -1,0 +1,13 @@
+"""Tiny shell-command helper shared by the PR-creation scripts."""
+
+import subprocess
+
+
+def run_command(cmd, check=True):
+    """Run a shell command and return its stdout, stripped."""
+    print(f"Running: {cmd}")
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        raise Exception(f"Command failed: {cmd}")
+    return result.stdout.strip()

--- a/src/components/CloudCard.astro
+++ b/src/components/CloudCard.astro
@@ -2,6 +2,7 @@
 import { asset } from "../lib/assets";
 import type { CloudWithSlug } from "../lib/clouds";
 import { compareIconAdd } from "../lib/compare-toggle-icons";
+import { EMERGING_CATEGORY, graduationIssueUrl } from "../lib/github";
 
 export interface Props {
   cloud: CloudWithSlug;
@@ -15,6 +16,8 @@ const score = cloud.score ?? 3;
 const badgeClass =
   score === 3 ? "bg-soft-sage text-rich-earth" : "bg-clay-beige text-warm-stone";
 const badgeText = `${score}/3`;
+const isEmerging = cloud.categories.includes(EMERGING_CATEGORY);
+const graduationHref = isEmerging ? graduationIssueUrl(cloud) : null;
 
 let host = "";
 try {
@@ -95,14 +98,28 @@ const detailHref = asset(`${cloud.slug}/`);
       class="text-sm font-medium text-bright-tangerine hover:underline inline-flex items-center gap-1.5 transition-all">
       Visit →
     </a>
-    {
-      featured && (
-        <a
-          href={detailHref}
-          class="text-xs font-medium text-warm-stone hover:text-rich-earth inline-flex items-center gap-1 transition-colors no-underline">
-          Details →
-        </a>
-      )
-    }
+    <div class="flex items-center gap-3">
+      {
+        graduationHref && (
+          <a
+            href={graduationHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Think this now meets the criteria? Open a re-check request."
+            class="text-xs font-medium text-warm-stone hover:text-rich-earth inline-flex items-center gap-1 transition-colors no-underline">
+            Request re-check
+          </a>
+        )
+      }
+      {
+        featured && (
+          <a
+            href={detailHref}
+            class="text-xs font-medium text-warm-stone hover:text-rich-earth inline-flex items-center gap-1 transition-colors no-underline">
+            Details →
+          </a>
+        )
+      }
+    </div>
   </div>
 </article>

--- a/src/components/EmergingBanner.astro
+++ b/src/components/EmergingBanner.astro
@@ -1,0 +1,33 @@
+---
+import { graduationIssueUrl } from "../lib/github";
+
+export interface Props {
+  cloud: { name: string; url: string };
+}
+
+const { cloud } = Astro.props;
+const requestUrl = graduationIssueUrl(cloud);
+---
+
+<div
+  class="mb-6 flex items-start gap-3 rounded-lg border border-clay-beige bg-cream px-4 py-3 text-sm text-warm-stone"
+  role="note"
+  aria-label="Emerging and unverified provider notice">
+  <span
+    class="mt-0.5 shrink-0 text-base"
+    aria-hidden="true"
+    >🌱</span
+  >
+  <div>
+    <span class="font-medium text-rich-earth">Emerging & Unverified Provider</span>
+    {" — "}listed, but still pending verification of pricing, self-service, or SLA details.
+    Think it now qualifies?{" "}
+    <a
+      href={requestUrl}
+      class="underline hover:text-rich-earth"
+      target="_blank"
+      rel="noopener noreferrer">
+      Request a re-check →
+    </a>
+  </div>
+</div>

--- a/src/layouts/CloudDetail.astro
+++ b/src/layouts/CloudDetail.astro
@@ -3,6 +3,8 @@ import Base from "./Base.astro";
 import DetailSidebar from "../components/DetailSidebar.astro";
 import DetailTopBar from "../components/DetailTopBar.astro";
 import DraftBanner from "../components/DraftBanner.astro";
+import EmergingBanner from "../components/EmergingBanner.astro";
+import { EMERGING_CATEGORY } from "../lib/github";
 import { defaultDescription, defaultTitle } from "../lib/site-meta";
 import { absoluteUrl } from "../lib/site-urls";
 import type { MergedCloud } from "../lib/profile";
@@ -13,6 +15,7 @@ export interface Props {
 }
 
 const { cloud, featuredSlugs } = Astro.props;
+const isEmerging = cloud.categories.includes(EMERGING_CATEGORY);
 
 const pageTitle = `${cloud.name} — ${defaultTitle}`;
 const pageDescription = cloud.tagline || cloud.description || defaultDescription;
@@ -87,6 +90,7 @@ const profileJsonLd = {
         </header>
 
         {cloud.status === "draft" && <DraftBanner slug={cloud.slug} />}
+        {isEmerging && <EmergingBanner cloud={cloud} />}
 
         <div class="prose-content">
           <slot />

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,30 @@
+export const GITHUB_OWNER = "datum-cloud";
+export const GITHUB_REPO = "awesome-alt-clouds";
+
+export const EMERGING_CATEGORY = "Emerging & Unverified Providers";
+
+/**
+ * Pre-filled "[Graduation] <Name>" issue link for a cloud currently listed
+ * under Emerging & Unverified Providers. Mirrors the shape the Alt Cloud
+ * browser extension already produces (see scripts/evaluate_graduation.py,
+ * which parses the `**Service:**` field back out) so both entry points
+ * feed the same bot pipeline.
+ */
+export function graduationIssueUrl(cloud: { name: string; url: string }): string {
+  const title = `[Graduation] ${cloud.name}`;
+  const body = `## Graduation Request
+
+**Service:** [${cloud.name}](${cloud.url})
+
+**Why they should graduate from Emerging & Unverified Providers to full listing:**
+
+
+**Evidence of criteria now met:**
+
+
+---
+*Reported via the Alt Cloud website.*`;
+
+  const params = new URLSearchParams({ title, body });
+  return `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/issues/new?${params.toString()}`;
+}

--- a/tests/test_audit_emerging_badges.py
+++ b/tests/test_audit_emerging_badges.py
@@ -1,0 +1,95 @@
+# tests/test_audit_emerging_badges.py
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from unittest.mock import patch
+
+import audit_emerging_badges as aeb
+
+SAMPLE_README = """# Awesome Alt Clouds
+
+## Databases & Storage
+
+* 🟢 [Alpha DB](https://alpha.example.com/) - A database.
+
+## Emerging & Unverified Providers
+
+* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database, needs verification.
+* 🟢 [LaunchDarkly](https://launchdarkly.com/) - Feature management, enterprise-only pricing.
+* 🟢 [Oxide Computer](https://oxide.computer/) - Rack-scale computer, sold as hardware.
+"""
+
+
+def _result(score):
+    return {
+        "url": "x",
+        "company_name": "x",
+        "score": score,
+        "criteria": [],
+        "fetch_failed": False,
+        "fetch_method": "requests",
+        "page_content": "",
+    }
+
+
+class TestAudit:
+    def test_corrects_mismatched_badges(self):
+        def fake_evaluate(url):
+            if "turbopuffer" in url:
+                return _result(3)
+            if "launchdarkly" in url:
+                return _result(2)
+            return _result(1)
+
+        with patch.object(aeb, "evaluate_service", side_effect=fake_evaluate):
+            new_content, changed, flagged, total = aeb.audit(SAMPLE_README)
+
+        assert total == 3
+        names_changed = {c["name"] for c in changed}
+        assert names_changed == {"LaunchDarkly", "Oxide Computer"}
+        assert "🟢 [Turbopuffer]" in new_content
+        assert "🟡 [LaunchDarkly]" in new_content
+        assert "🟡 [Oxide Computer]" in new_content
+
+    def test_flags_entries_scoring_below_two(self):
+        with patch.object(aeb, "evaluate_service", return_value=_result(1)):
+            _, _, flagged, _ = aeb.audit(SAMPLE_README)
+
+        assert len(flagged) == 3
+        assert all(f["score"] == 1 for f in flagged)
+
+    def test_leaves_readme_untouched_outside_emerging_section(self):
+        with patch.object(aeb, "evaluate_service", return_value=_result(1)):
+            new_content, _, _, _ = aeb.audit(SAMPLE_README)
+
+        assert "🟢 [Alpha DB]" in new_content
+
+
+class TestMain:
+    def test_writes_report_and_updates_readme_on_change(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        with patch.object(aeb, "evaluate_service", return_value=_result(2)):
+            aeb.main()
+
+        report = (tmp_path / "audit_report.md").read_text()
+        assert "Badges corrected" in report
+        readme = (tmp_path / "README.md").read_text()
+        assert "🟡 [Turbopuffer]" in readme
+
+    def test_no_op_when_no_entries_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        no_emerging_section = (
+            "# Awesome Alt Clouds\n\n"
+            "## Databases & Storage\n\n"
+            "* 🟢 [Alpha DB](https://alpha.example.com/) - A database.\n"
+        )
+        (tmp_path / "README.md").write_text(no_emerging_section)
+
+        aeb.main()
+
+        report = (tmp_path / "audit_report.md").read_text()
+        assert "nothing to audit" in report

--- a/tests/test_create_graduation_pr.py
+++ b/tests/test_create_graduation_pr.py
@@ -1,0 +1,148 @@
+# tests/test_create_graduation_pr.py
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from unittest.mock import patch
+
+import create_graduation_pr as cg
+
+SAMPLE_README = """# Awesome Alt Clouds
+
+## Databases & Storage
+
+* 🟢 [Alpha DB](https://alpha.example.com/) - A database.
+
+## Emerging & Unverified Providers
+
+* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database, needs verification.
+"""
+
+GRADUATION_DATA = {
+    "issue_number": "326",
+    "name": "Turbopuffer",
+    "url": "https://turbopuffer.com/",
+    "old_category": "Emerging & Unverified Providers",
+    "new_category": "Databases & Storage",
+    "score": 3,
+    "description": "Fast serverless vector database.",
+    "needs_manual_review": False,
+}
+
+
+class TestMoveEntryInReadme:
+    def test_moves_entry_between_categories(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        assert cg.move_entry_in_readme(GRADUATION_DATA) is True
+
+        content = (tmp_path / "README.md").read_text()
+        db_start = content.index("## Databases & Storage")
+        emerging_start = content.index("## Emerging & Unverified Providers")
+        turbopuffer_idx = content.index("Turbopuffer")
+        assert db_start < turbopuffer_idx < emerging_start
+        assert "Fast serverless vector database." in content
+
+    def test_returns_false_when_entry_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        data = {**GRADUATION_DATA, "name": "Nonexistent"}
+        assert cg.move_entry_in_readme(data) is False
+
+    def test_returns_false_when_category_drifted(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        data = {**GRADUATION_DATA, "old_category": "Cloud Adjacent & Infrastructure Tooling"}
+        assert cg.move_entry_in_readme(data) is False
+
+    def test_returns_false_when_target_category_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        data = {**GRADUATION_DATA, "new_category": "Nonexistent Category"}
+        assert cg.move_entry_in_readme(data) is False
+
+
+class TestCreatePr:
+    def test_runs_expected_git_and_gh_commands(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        commands = []
+
+        def fake_run_command(cmd, check=True):
+            commands.append(cmd)
+            if cmd.startswith("gh pr list"):
+                return ""
+            return ""
+
+        with patch.object(cg, "run_command", side_effect=fake_run_command):
+            result = cg.create_pr(GRADUATION_DATA)
+
+        assert result is True
+        assert any(c.startswith("git checkout -b graduation-326-turbopuffer") for c in commands)
+        assert any(c == "git add README.md" for c in commands)
+        assert any("git commit" in c and "Graduate Turbopuffer" in c for c in commands)
+        assert any(
+            c.startswith("git push --force origin graduation-326-turbopuffer") for c in commands
+        )
+        assert any(c.startswith("gh pr create") for c in commands)
+
+    def test_skips_pr_creation_if_branch_already_has_open_pr(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        commands = []
+
+        def fake_run_command(cmd, check=True):
+            commands.append(cmd)
+            if cmd.startswith("gh pr list"):
+                return "42"
+            return ""
+
+        with patch.object(cg, "run_command", side_effect=fake_run_command):
+            result = cg.create_pr(GRADUATION_DATA)
+
+        assert result is True
+        assert not any(c.startswith("gh pr create") for c in commands)
+
+    def test_returns_false_when_readme_move_fails(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+
+        data = {**GRADUATION_DATA, "name": "Nonexistent"}
+        commands = []
+
+        with patch.object(
+            cg, "run_command", side_effect=lambda cmd, check=True: commands.append(cmd)
+        ):
+            result = cg.create_pr(data)
+
+        assert result is False
+        assert not any("git commit" in c for c in commands)
+
+
+class TestMain:
+    def test_no_op_when_no_data_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert cg.main() == 0
+
+    def test_returns_zero_on_success(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "graduation_data.json").write_text(json.dumps(GRADUATION_DATA))
+
+        with patch.object(cg, "create_pr", return_value=True) as mock_create:
+            assert cg.main() == 0
+        mock_create.assert_called_once_with(GRADUATION_DATA)
+
+    def test_returns_one_on_exception(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "graduation_data.json").write_text(json.dumps(GRADUATION_DATA))
+
+        with patch.object(cg, "create_pr", side_effect=RuntimeError("boom")):
+            assert cg.main() == 1

--- a/tests/test_evaluate_graduation.py
+++ b/tests/test_evaluate_graduation.py
@@ -1,0 +1,202 @@
+# tests/test_evaluate_graduation.py
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from unittest.mock import patch
+
+import evaluate_graduation as eg
+
+SAMPLE_README = """# Awesome Alt Clouds
+
+## Databases & Storage
+
+* 🟢 [Alpha DB](https://alpha.example.com/) - A database.
+
+## Emerging & Unverified Providers
+
+* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database, needs verification.
+"""
+
+GRADUATION_BODY = """## Graduation Request
+
+**Service:** [Turbopuffer](https://turbopuffer.com/)
+
+**Why they should graduate from Future Cloud to full listing:**
+Pricing is transparent now.
+
+---
+*Reported via the Alt Cloud browser extension.*
+"""
+
+
+def _evaluate_result(score, criteria=None):
+    return {
+        "url": "https://turbopuffer.com/",
+        "company_name": "Turbopuffer",
+        "score": score,
+        "criteria": criteria
+        or [
+            {
+                "name": "Transparent Public Pricing",
+                "passed": True,
+                "evidence": "https://turbopuffer.com/pricing",
+            },
+            {"name": "Usage-based Self-Service", "passed": True, "evidence": "Sign up"},
+            {
+                "name": "Production Indicators",
+                "passed": score == 3,
+                "evidence": "status page" if score == 3 else "none",
+            },
+        ],
+        "fetch_failed": False,
+        "fetch_method": "requests",
+        "page_content": "some content",
+    }
+
+
+class TestExtractServiceName:
+    def test_prefers_service_field_in_body(self):
+        name = eg.extract_service_name("[Graduation] Turbopuffer", GRADUATION_BODY)
+        assert name == "Turbopuffer"
+
+    def test_falls_back_to_title_when_body_field_missing(self):
+        name = eg.extract_service_name("[Graduation] Turbopuffer", "no service field here")
+        assert name == "Turbopuffer"
+
+    def test_falls_back_to_title_with_request_suffix(self):
+        name = eg.extract_service_name("[Graduation Request] Turbopuffer", "no service field here")
+        assert name == "Turbopuffer"
+
+    def test_returns_none_when_nothing_matches(self):
+        assert eg.extract_service_name("Some random issue", "no service field here") is None
+
+
+class TestMainFlow:
+    def test_writes_error_when_name_not_extractable(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", "nothing useful")
+        monkeypatch.setenv("ISSUE_TITLE", "Some random issue")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+
+        eg.main()
+
+        assert (
+            "Could not determine which service" in (tmp_path / "graduation_results.md").read_text()
+        )
+        assert (tmp_path / "graduation_score.txt").read_text() == "0"
+        assert not (tmp_path / "graduation_data.json").exists()
+
+    def test_writes_error_when_entry_not_in_readme(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv(
+            "ISSUE_BODY", "**Service:** [Nonexistent](https://nonexistent.example.com/)"
+        )
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Nonexistent")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+
+        eg.main()
+
+        assert (
+            "Could not find an existing README.md entry"
+            in (tmp_path / "graduation_results.md").read_text()
+        )
+        assert not (tmp_path / "graduation_data.json").exists()
+
+    def test_writes_error_when_entry_already_graduated(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", "**Service:** [Alpha DB](https://alpha.example.com/)")
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Alpha DB")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+
+        eg.main()
+
+        result = (tmp_path / "graduation_results.md").read_text()
+        assert "already listed under" in result
+        assert "Databases & Storage" in result
+
+    def test_ready_to_graduate_writes_data_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", GRADUATION_BODY)
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Turbopuffer")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+
+        ai_metadata = {
+            "name": "Turbopuffer",
+            "description": "Fast serverless vector database.",
+            "category": "Databases & Storage",
+        }
+
+        with patch.object(eg, "evaluate_service", return_value=_evaluate_result(3)):
+            with patch.object(eg, "generate_metadata", return_value=ai_metadata):
+                eg.main()
+
+        assert (tmp_path / "graduation_score.txt").read_text() == "3"
+        data = json.loads((tmp_path / "graduation_data.json").read_text())
+        assert data["name"] == "Turbopuffer"
+        assert data["old_category"] == "Emerging & Unverified Providers"
+        assert data["new_category"] == "Databases & Storage"
+        assert data["score"] == 3
+
+        comment = (tmp_path / "graduation_results.md").read_text()
+        assert "ready to graduate" in comment
+        assert "/approve-graduation" in comment
+
+    def test_low_score_does_not_write_data_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", GRADUATION_BODY)
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Turbopuffer")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+
+        with patch.object(eg, "evaluate_service", return_value=_evaluate_result(1)):
+            with patch.object(eg, "generate_metadata", return_value=None):
+                eg.main()
+
+        assert (tmp_path / "graduation_score.txt").read_text() == "1"
+        assert not (tmp_path / "graduation_data.json").exists()
+        comment = (tmp_path / "graduation_results.md").read_text()
+        assert "Still doesn't meet the bar" in comment
+
+    def test_admin_approved_bypasses_score_gate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", GRADUATION_BODY)
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Turbopuffer")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+        monkeypatch.setenv("GRADUATION_ADMIN_APPROVED", "true")
+        monkeypatch.setenv("GRADUATION_CATEGORY_OVERRIDE", "Databases & Storage")
+
+        with patch.object(eg, "evaluate_service", return_value=_evaluate_result(1)):
+            with patch.object(eg, "generate_metadata", return_value=None):
+                eg.main()
+
+        data = json.loads((tmp_path / "graduation_data.json").read_text())
+        assert data["new_category"] == "Databases & Storage"
+
+    def test_unknown_category_override_is_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        monkeypatch.setenv("ISSUE_BODY", GRADUATION_BODY)
+        monkeypatch.setenv("ISSUE_TITLE", "[Graduation] Turbopuffer")
+        monkeypatch.setenv("ISSUE_NUMBER", "326")
+        monkeypatch.setenv("GRADUATION_CATEGORY_OVERRIDE", "Not A Real Category")
+
+        ai_metadata = {
+            "name": "Turbopuffer",
+            "description": "Fast serverless vector database.",
+            "category": "Databases & Storage",
+        }
+
+        with patch.object(eg, "evaluate_service", return_value=_evaluate_result(3)):
+            with patch.object(eg, "generate_metadata", return_value=ai_metadata):
+                eg.main()
+
+        data = json.loads((tmp_path / "graduation_data.json").read_text())
+        assert data["new_category"] == "Databases & Storage"

--- a/tests/test_readme_entries.py
+++ b/tests/test_readme_entries.py
@@ -1,0 +1,143 @@
+# tests/test_readme_entries.py
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from lib import readme_entries as re_lib
+
+SAMPLE_README = """# Awesome Alt Clouds
+
+## Databases & Storage
+
+* 🟢 [Alpha DB](https://alpha.example.com/) - A database.
+* 🟢 [Zeta Storage](https://zeta.example.com/) - Storage service.
+
+## Emerging & Unverified Providers
+
+* 🟢 [Turbopuffer](https://turbopuffer.com/) - Vector database, needs verification.
+* 🟢 [Uptrace](https://uptrace.dev/) - Tracing platform, needs verification.
+
+## Cloud Adjacent & Infrastructure Tooling
+
+* 🟢 [ngrok](https://ngrok.com/) - Tunnels local services.
+"""
+
+
+class TestFindCategorySection:
+    def test_finds_section_bounds(self):
+        start, end = re_lib.find_category_section(SAMPLE_README, "Emerging & Unverified Providers")
+        lines = SAMPLE_README.split("\n")
+        assert lines[start].strip() == "## Emerging & Unverified Providers"
+        assert lines[end].strip() == "## Cloud Adjacent & Infrastructure Tooling"
+
+    def test_last_section_runs_to_end_of_file(self):
+        start, end = re_lib.find_category_section(
+            SAMPLE_README, "Cloud Adjacent & Infrastructure Tooling"
+        )
+        assert end == len(SAMPLE_README.split("\n"))
+
+    def test_missing_category_returns_none(self):
+        start, end = re_lib.find_category_section(SAMPLE_README, "Nonexistent Category")
+        assert start is None
+        assert end is None
+
+
+class TestBadgeForScore:
+    def test_three_of_three_is_green(self):
+        assert re_lib.badge_for_score(3) == "🟢"
+
+    def test_two_of_three_is_yellow(self):
+        assert re_lib.badge_for_score(2) == "🟡"
+
+    def test_below_two_is_yellow(self):
+        assert re_lib.badge_for_score(1) == "🟡"
+
+
+class TestAddEntryToReadme:
+    def test_inserts_alphabetically_within_category(self):
+        submission = {
+            "name": "Beta Cloud",
+            "url": "https://beta.example.com/",
+            "category": "Databases & Storage",
+            "score": 3,
+            "description": "A cloud.",
+        }
+        new_content = re_lib.add_entry_to_readme(submission, content=SAMPLE_README)
+        lines = new_content.split("\n")
+        alpha_idx = next(i for i, line in enumerate(lines) if "Alpha DB" in line)
+        beta_idx = next(i for i, line in enumerate(lines) if "Beta Cloud" in line)
+        zeta_idx = next(i for i, line in enumerate(lines) if "Zeta Storage" in line)
+        assert alpha_idx < beta_idx < zeta_idx
+
+    def test_uses_yellow_badge_for_score_two(self):
+        submission = {
+            "name": "Beta Cloud",
+            "url": "https://beta.example.com/",
+            "category": "Databases & Storage",
+            "score": 2,
+            "description": "A cloud.",
+        }
+        new_content = re_lib.add_entry_to_readme(submission, content=SAMPLE_README)
+        assert "🟡 [Beta Cloud]" in new_content
+
+    def test_returns_none_when_category_missing(self):
+        submission = {
+            "name": "Beta Cloud",
+            "url": "https://beta.example.com/",
+            "category": "Nonexistent Category",
+            "score": 3,
+            "description": "A cloud.",
+        }
+        assert re_lib.add_entry_to_readme(submission, content=SAMPLE_README) is None
+
+    def test_writes_to_file_when_no_content_given(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "README.md").write_text(SAMPLE_README)
+        submission = {
+            "name": "Beta Cloud",
+            "url": "https://beta.example.com/",
+            "category": "Databases & Storage",
+            "score": 3,
+            "description": "A cloud.",
+        }
+        result = re_lib.add_entry_to_readme(submission)
+        assert result is True
+        assert "Beta Cloud" in (tmp_path / "README.md").read_text()
+
+
+class TestFindEntryByName:
+    def test_finds_entry_and_its_category(self):
+        entry = re_lib.find_entry_by_name(SAMPLE_README, "Turbopuffer")
+        assert entry["category"] == "Emerging & Unverified Providers"
+        assert entry["url"] == "https://turbopuffer.com/"
+        assert entry["badge"] == "🟢"
+
+    def test_is_case_insensitive(self):
+        entry = re_lib.find_entry_by_name(SAMPLE_README, "turbopuffer")
+        assert entry is not None
+
+    def test_exact_match_not_substring(self):
+        # "Split" must not match a hypothetical "Splitwise" entry.
+        content = SAMPLE_README + "\n* 🟢 [Splitwise](https://splitwise.com/) - Bill splitting.\n"
+        assert re_lib.find_entry_by_name(content, "Split") is None
+
+    def test_returns_none_when_not_found(self):
+        assert re_lib.find_entry_by_name(SAMPLE_README, "Nonexistent Service") is None
+
+
+class TestRemoveEntryFromReadme:
+    def test_removes_the_line(self):
+        entry = re_lib.find_entry_by_name(SAMPLE_README, "Turbopuffer")
+        new_content = re_lib.remove_entry_from_readme(SAMPLE_README, entry["line_idx"])
+        assert "Turbopuffer" not in new_content
+        assert "Uptrace" in new_content
+
+
+class TestListEntriesInCategory:
+    def test_lists_all_entries_in_order(self):
+        entries = re_lib.list_entries_in_category(SAMPLE_README, "Emerging & Unverified Providers")
+        assert [e["name"] for e in entries] == ["Turbopuffer", "Uptrace"]
+
+    def test_empty_for_missing_category(self):
+        assert re_lib.list_entries_in_category(SAMPLE_README, "Nonexistent Category") == []


### PR DESCRIPTION
## Summary

Closes #326-style requests. `[Graduation] <Name>` issues (currently filed by the Alt Cloud browser extension, e.g. #326 for Turbopuffer) had no automation — nothing re-evaluated the service or moved it out of Emerging & Unverified Providers. This adds that pipeline end-to-end, plus a matching trigger on the website itself.

**Backend automation**
- `graduation-request.yml` + `evaluate_graduation.py`: re-runs the existing `evaluate_service()`/`generate_metadata()` cascade against the service's current README.md entry and comments the fresh score. Labels `graduation-request` (+ `graduation-ready` at 2/3+).
- `approve-graduation.yml` + `create_graduation_pr.py`: maintainer confirms with `/approve-graduation [Category Name]`, opening a PR that moves the entry out of Emerging & Unverified Providers into its real category. Nothing touches README.md without that explicit command — same gate the existing `/approve` submission flow uses.
- Extracted `find_category_section`/`add_entry_to_readme` (plus new `find_entry_by_name`/`remove_entry_from_readme`/`list_entries_in_category`) out of `create_submission_pr.py` into `scripts/lib/readme_entries.py`, shared by both PR-creation scripts.
- `audit_emerging_badges.py` + a `workflow_dispatch`-only workflow to fix the section's badges, which currently show 🟢 regardless of real score. Sub-2/3 entries are flagged for manual review, never auto-removed.

**Website trigger**
- `src/lib/github.ts` builds the identical issue title/body shape the browser extension already produces (a `**Service:**` markdown-link field `evaluate_graduation.py` parses back out), so both entry points feed the same bot pipeline.
- `CloudCard` shows a "Request re-check" link on any card whose category is Emerging & Unverified Providers (homepage grid + category pages).
- `CloudDetail` shows a fuller `EmergingBanner` (mirrors the existing `DraftBanner` pattern) on a service's own detail page.

**Docs**: `CLAUDE.md` (architecture), `CONTRIBUTING.md` (contributor-facing flow), `README.md` (points readers at the new issue path from the Emerging section itself).

## Test plan

- [x] `pytest tests/` — 134 passed (43 new)
- [x] `ruff check` clean on all touched/new Python files
- [x] `npm run check` (astro check) — 0 errors
- [x] `npx eslint` on touched files — clean
- [x] `npm run build` — verified end-to-end: Turbopuffer's live detail page (`/turbopuffer/`) renders the banner and produces a correctly pre-filled `[Graduation] Turbopuffer` issue URL with the `**Service:**` field `evaluate_graduation.py` expects
- [ ] Maintainer smoke test: open a real `[Graduation]` issue against a test entry and confirm the full comment → `/approve-graduation` → PR flow