### PR TITLE
Group Emerging & Unverified Providers in nav + refresh SEO meta copy

### DIFF
--- a/site.config.mjs
+++ b/site.config.mjs
@@ -21,15 +21,17 @@ export const siteConfig = {
   productionBase: undefined,
 
   seo: {
-    title: "Awesome Alt Clouds | Alternative Cloud Providers for Developers",
+    title: "Alternative Cloud Providers Directory - 470+ Options | Neo Cloud Comparison Tool",
     description:
-      "Discover specialized cloud infrastructure providers built for developers who have specialized requirements and need alternatives to hyperscalers.",
+      "Compare 470+ specialized cloud, GPU, and infrastructure providers across pricing, regions, and uptime.",
+    /** Short brand suffix for templated per-page titles (cloud detail, category, compare) — kept separate from `title` above so those don't inherit the long homepage-specific title. */
+    siteName: "Neo Cloud Comparison Tool",
     /** Appended to titles when `preview: true` (browser tab clarity on fork deploys) */
     previewTitleSuffix: " (Preview)",
     submit: {
-      title: "Add a Cloud - Awesome Alt Clouds",
+      title: "Submit your cloud provider for listing | Neo Cloud Comparison Tool",
       description:
-        "Submit a cloud service for evaluation against the 3 inclusion criteria. Auto-evaluated by our bot.",
+        "List your alternative cloud service, auto-evaluated against 3 core criteria: public pricing, self-serve signup, transparent uptime",
     },
     blog: {
       title: "Blog | Awesome Alt Clouds",

--- a/src/layouts/CloudDetail.astro
+++ b/src/layouts/CloudDetail.astro
@@ -5,7 +5,7 @@ import DetailTopBar from "../components/DetailTopBar.astro";
 import DraftBanner from "../components/DraftBanner.astro";
 import EmergingBanner from "../components/EmergingBanner.astro";
 import { EMERGING_CATEGORY } from "../lib/github";
-import { defaultDescription, defaultTitle } from "../lib/site-meta";
+import { defaultDescription, siteName } from "../lib/site-meta";
 import { absoluteUrl } from "../lib/site-urls";
 import type { MergedCloud } from "../lib/profile";
 
@@ -17,7 +17,7 @@ export interface Props {
 const { cloud, featuredSlugs } = Astro.props;
 const isEmerging = cloud.categories.includes(EMERGING_CATEGORY);
 
-const pageTitle = `${cloud.name} — ${defaultTitle}`;
+const pageTitle = `${cloud.name} | ${siteName}`;
 const pageDescription = cloud.tagline || cloud.description || defaultDescription;
 const canonical = `${absoluteUrl(cloud.slug)}/`;
 

--- a/src/lib/site-meta.ts
+++ b/src/lib/site-meta.ts
@@ -12,6 +12,9 @@ function withPreviewTitle(title: string): string {
 export const defaultTitle = withPreviewTitle(seo.title);
 export const defaultDescription = seo.description;
 
+/** Short brand suffix for templated per-page titles (cloud detail, category, compare). */
+export const siteName = withPreviewTitle(seo.siteName);
+
 export const submitTitle = withPreviewTitle(seo.submit.title);
 export const submitDescription = seo.submit.description;
 

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -12,7 +12,7 @@ import {
   getCategories,
 } from "../../lib/clouds";
 import { getFeaturedSlugs } from "../../lib/profile";
-import { defaultTitle } from "../../lib/site-meta";
+import { siteName } from "../../lib/site-meta";
 import { absoluteUrl } from "../../lib/site-urls";
 
 export function getStaticPaths() {
@@ -36,7 +36,7 @@ const categoryClouds = [...clouds]
 const featuredSlugs = await getFeaturedSlugs();
 const providerCount = countByCategory(category);
 const description = getCategoryDescription(category);
-const pageTitle = `${category} — ${defaultTitle}`;
+const pageTitle = `${category} | ${siteName}`;
 const canonical = `${absoluteUrl("categories/" + slug)}/`;
 
 const itemListJsonLd = {

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -7,12 +7,12 @@ import DirectorySidebar from "../components/DirectorySidebar.astro";
 import { COMPARE_ROWS, toCompareCloud, type CompareCloud } from "../lib/compare";
 import { clouds } from "../lib/clouds";
 import { getAllMergedClouds, getFeaturedSlugs } from "../lib/profile";
-import { defaultTitle } from "../lib/site-meta";
 import { absoluteUrl } from "../lib/site-urls";
 
-const pageTitle = `Compare alt clouds — ${defaultTitle}`;
+const pageTitle =
+  "Compare Alternative Cloud Providers - Pricing, Uptime, and Regions | Neo Cloud Comparison Tool";
 const pageDescription =
-  "Side-by-side comparison of alternative cloud providers — criteria scores, pricing models, regions, and more.";
+  "Get side-by-side comparisons of alternative cloud, neo cloud, and specialized cloud providers";
 const canonical = `${absoluteUrl("compare")}/`;
 
 const featuredSlugs = await getFeaturedSlugs();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,6 +90,14 @@ const featuredSlugs = await getFeaturedSlugs();
         class="flex flex-col gap-1"
         id="drawerCategoryList">
       </div>
+
+      <div class="font-serif text-xs font-semibold uppercase tracking-wider text-warm-stone mt-5 mb-3">
+        Tracking
+      </div>
+      <div
+        class="flex flex-col gap-1"
+        id="drawerTrackingList">
+      </div>
     </div>
     <div class="p-4 border-t border-clay-beige flex flex-col gap-1 flex-shrink-0">
       <a
@@ -188,7 +196,16 @@ const featuredSlugs = await getFeaturedSlugs();
         </div>
         <div
           class="flex flex-col gap-1"
-          id="categoryList">
+          id="categoryList"
+          data-watchlist-href={asset("watchlist/")}>
+        </div>
+
+        <div class="font-serif text-xs font-semibold uppercase tracking-wider text-warm-stone mt-5 mb-3">
+          Tracking
+        </div>
+        <div
+          class="flex flex-col gap-1"
+          id="trackingList">
         </div>
       </div>
 
@@ -618,6 +635,8 @@ const featuredSlugs = await getFeaturedSlugs();
   />
 
   <script>
+    import { EMERGING_CATEGORY } from "../lib/github";
+
     type Cloud = {
       name: string;
       url: string;
@@ -750,25 +769,39 @@ const featuredSlugs = await getFeaturedSlugs();
 
     // Categories rendering
     function renderCategories() {
-      const cats = getCategories();
       const counts: Record<string, number> = { All: altClouds.length };
       for (const c of altClouds) {
         for (const cat of c.categories) counts[cat] = (counts[cat] || 0) + 1;
       }
-      const html = cats
-        .map((cat) => {
-          const isActive = cat === currentCategory;
-          return `<button data-category="${cat.replace(/"/g, "&quot;")}" class="gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent ${
-            isActive
-              ? "bg-rich-earth text-cream font-medium"
-              : "text-warm-stone hover:bg-clay-beige hover:text-rich-earth"
-          }"><span>${cat}</span><span class="font-mono text-xs opacity-70">${counts[cat] || 0}</span></button>`;
-        })
-        .join("");
+
+      const categoryButtonHtml = (cat: string) => {
+        const isActive = cat === currentCategory;
+        return `<button data-category="${cat.replace(/"/g, "&quot;")}" class="gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent ${
+          isActive
+            ? "bg-rich-earth text-cream font-medium"
+            : "text-warm-stone hover:bg-clay-beige hover:text-rich-earth"
+        }"><span>${cat}</span><span class="font-mono text-xs opacity-70">${counts[cat] || 0}</span></button>`;
+      };
+
+      // "Emerging & Unverified Providers" is grouped with Watchlist in its own
+      // "Tracking" section below, not the main alphabetical category list —
+      // both are candidates that haven't fully cleared the bar yet.
+      const cats = getCategories().filter((cat) => cat !== EMERGING_CATEGORY);
+      const html = cats.map(categoryButtonHtml).join("");
       const list = document.getElementById("categoryList");
       const drawerList = document.getElementById("drawerCategoryList");
       if (list) list.innerHTML = html;
       if (drawerList) drawerList.innerHTML = html;
+
+      const watchlistHref = list?.dataset.watchlistHref || "#";
+      const trackingHtml =
+        `<a href="${watchlistHref}" class="gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent text-warm-stone hover:bg-clay-beige hover:text-rich-earth no-underline"><span>Watchlist</span></a>` +
+        categoryButtonHtml(EMERGING_CATEGORY);
+      const trackingList = document.getElementById("trackingList");
+      const drawerTrackingList = document.getElementById("drawerTrackingList");
+      if (trackingList) trackingList.innerHTML = trackingHtml;
+      if (drawerTrackingList) drawerTrackingList.innerHTML = trackingHtml;
+
       document.querySelectorAll<HTMLElement>("[data-category]").forEach((btn) => {
         btn.addEventListener("click", () => {
           const cat = btn.getAttribute("data-category");

--- a/src/pages/watchlist/index.astro
+++ b/src/pages/watchlist/index.astro
@@ -13,8 +13,8 @@ const featuredSlugs = [...(await getFeaturedSlugs())];
 ---
 
 <Base
-  title="Watchlist | Awesome Alt Clouds"
-  description="Services with real potential that haven't crossed the qualification threshold yet — tracked with a clear path forward."
+  title="Emerging Cloud Providers to Watch | Neo Cloud Comparison Tool"
+  description="Alternative & Neo Cloud Providers with potential that haven't cleared the criteria yet, tracked with a clear path to listing."
   canonical={watchlistCanonical}>
   <div class="flex flex-col md:flex-row min-h-screen">
     <DirectorySidebar activePage="watchlist" />


### PR DESCRIPTION
## Summary

Two related changes bundled on this branch:

**1. Nav: group Emerging & Unverified Providers with Watchlist**

"Emerging & Unverified Providers" was listed as a plain peer inside the flat, alphabetical list of all 23 categories in the homepage sidebar (desktop + mobile drawer) — indistinguishable from real categories like "Databases & Storage". It's conceptually much closer to the Watchlist: both track candidates that haven't fully cleared the bar yet (Watchlist: 1/3 score, unpublished; Emerging: published but flagged pending verification).

Pulls it out of the main category list into a small "Tracking" section grouped with Watchlist, in both the desktop sidebar and mobile drawer. Scoped to navigation only — category value, badges, filtering behavior, `clouds.json`/`evaluate_submission.py` taxonomy, and the category's own detail page are all unchanged. Clicking "Emerging & Unverified Providers" in the new group still filters the homepage grid in place, same as every other category button.

**2. SEO: refresh meta title/description on Home, Compare, Submit, Watchlist**

Keyword research (SEMrush) showed "alt cloud" has low search volume. Updated copy targets "neo cloud" / "alternative cloud provider" terms instead:

| Page | Title | Description |
|------|-------|-------------|
| Home | Alternative Cloud Providers Directory - 470+ Options \| Neo Cloud Comparison Tool | Compare 470+ specialized cloud, GPU, and infrastructure providers across pricing, regions, and uptime. |
| Compare | Compare Alternative Cloud Providers - Pricing, Uptime, and Regions \| Neo Cloud Comparison Tool | Get side-by-side comparisons of alternative cloud, neo cloud, and specialized cloud providers |
| Submit | Submit your cloud provider for listing \| Neo Cloud Comparison Tool | List your alternative cloud service, auto-evaluated against 3 core criteria: public pricing, self-serve signup, transparent uptime |
| Watchlist | Emerging Cloud Providers to Watch \| Neo Cloud Comparison Tool | Alternative & Neo Cloud Providers with potential that haven't cleared the criteria yet, tracked with a clear path to listing. |

Necessary side-fix: `CloudDetail.astro`, `categories/[slug].astro`, and `compare.astro` previously templated their own titles off the site-wide `defaultTitle` (e.g. `${cloud.name} — ${defaultTitle}`). Since `defaultTitle` is now the much longer homepage-specific title, those three would have inherited it on every single cloud/category page. Introduced `site-meta.ts:siteName` — a short "Neo Cloud Comparison Tool" brand suffix — for those templated titles instead, so per-page titles stay reasonably sized.

Note: the two longest titles (Home at 80 chars, Compare at 94) are past the ~60-char point where Google typically starts truncating in the SERP snippet — flagging for awareness, kept as specified since it's from deliberate keyword research.

## Test plan

- [x] `npm run check` (astro check) — 0 errors
- [x] `npx eslint` on all touched files — clean
- [x] `npm run build` — 428 pages built successfully
- [x] Verified rendered `<title>`/`<meta description>` in `dist/` output match the spec exactly for all 4 pages
- [x] Verified `CloudDetail`/category page titles use the short `siteName` suffix, not the full homepage title (e.g. `Turbopuffer | Neo Cloud Comparison Tool`)
- [x] Verified in `npm run dev`: static skeleton + compiled client script for the Tracking nav section
- [x] `pytest tests/` — 134 passed (unaffected, Python-side unchanged)
- [ ] Maintainer visual check on a preview deploy (desktop sidebar + mobile drawer + page titles)