### PR TITLE
Move Emerging nav link to persistent sidebar + drop "Awesome" from brand name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Awesome Alt Clouds
+# Contributing to Alt Cloud
 
 Thanks for your interest in contributing! There are now three different things you can contribute to, each with a different workflow.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌥️ Awesome Alt Clouds [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# 🌥️ Alt Cloud [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 [<img src='altclouds-logo.png' align='right' width='100'>](https://www.alt-cloud.org/)
 

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -235,7 +235,7 @@ def build_comment(match_type: str, match: dict) -> str:
     if match_type == 'exact_domain':
         return (
             '⚠️ **Duplicate Submission**\n\n'
-            'This service is already included in the Awesome Alt Clouds list:\n'
+            'This service is already included in the Alt Cloud list:\n'
             f'- **[{name}]({url})** — {desc}\n\n'
             'Closing this issue as a duplicate. If you believe this is a different '
             'service or a significant update, please reopen with additional context.'
@@ -250,7 +250,7 @@ def build_comment(match_type: str, match: dict) -> str:
     elif match_type == 'redirect_domain':
         return (
             '🔁 **Duplicate via Domain Redirect**\n\n'
-            'This URL redirects to a service already listed in Awesome Alt Clouds '
+            'This URL redirects to a service already listed in Alt Cloud '
             '(confirmed via HTTP redirect, not just name similarity):\n'
             f'- **[{name}]({url})** — {desc}\n\n'
             'Proceeding with admin review, but flagging as a likely duplicate.'

--- a/scripts/evaluate_submission.py
+++ b/scripts/evaluate_submission.py
@@ -846,7 +846,7 @@ def generate_markdown_results(results_list):
 No services passed the evaluation criteria. Please review and resubmit.
 """
 
-    md += "\n*Evaluated automatically by the Awesome Alt Clouds bot*"
+    md += "\n*Evaluated automatically by the Alt Cloud bot*"
 
     return md
 

--- a/scripts/generate_llms.py
+++ b/scripts/generate_llms.py
@@ -88,7 +88,7 @@ def generate_llms_txt(clouds: list[dict]) -> str:
     top5 = ", ".join(f"{cat} ({n})" for cat, n, _ in stats[:5])
 
     lines = [
-        "# Awesome Alt Clouds",
+        "# Alt Cloud",
         "",
         f"> Curated directory of {total}+ alternative cloud providers for developers — covering {num_cats} categories including infrastructure, GPU compute, databases, AI inference, observability, developer tooling, and more. Each service is evaluated against 3 public criteria.",
         "",
@@ -238,7 +238,7 @@ def generate_llms_full_txt(clouds: list[dict]) -> str:
     sections: list[str] = []
 
     # Header
-    sections.append("# Awesome Alt Clouds — Full Reference")
+    sections.append("# Alt Cloud — Full Reference")
     sections.append("")
     sections.append(
         f"> Curated directory of {total}+ alternative cloud providers for developers who need "

--- a/site.config.mjs
+++ b/site.config.mjs
@@ -34,9 +34,9 @@ export const siteConfig = {
         "List your alternative cloud service, auto-evaluated against 3 core criteria: public pricing, self-serve signup, transparent uptime",
     },
     blog: {
-      title: "Blog | Awesome Alt Clouds",
+      title: "Blog | Alt Cloud",
       description:
-        "Editorial notes on alternative cloud providers — trends, new entrants, and commentary from the Awesome Alt Clouds community.",
+        "Editorial notes on alternative cloud providers — trends, new entrants, and commentary from the Alt Cloud community.",
     },
   },
 };

--- a/src/components/DirectorySidebar.astro
+++ b/src/components/DirectorySidebar.astro
@@ -1,19 +1,24 @@
 ---
 import { asset } from "../lib/assets";
+import { categoryToSlug } from "../lib/clouds";
+import { EMERGING_CATEGORY } from "../lib/github";
 import SidebarFooterNav from "./SidebarFooterNav.astro";
 
+export type ActivePage = "directory" | "watchlist" | "emerging" | "blog" | "compare";
+
 export interface Props {
-  activePage?: "directory" | "watchlist" | "blog" | "compare";
+  activePage?: ActivePage;
 }
 
 const { activePage = "directory" } = Astro.props;
 
 const homeHref = asset("");
 const watchlistHref = asset("watchlist/");
+const emergingHref = asset(`categories/${categoryToSlug(EMERGING_CATEGORY)}/`);
 const blogHref = asset("blog/");
 const compareHref = asset("compare/");
 
-const navClass = (page: "directory" | "watchlist" | "blog" | "compare") =>
+const navClass = (page: ActivePage) =>
   [
     "flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm no-underline transition-colors",
     activePage === page
@@ -67,6 +72,17 @@ const navClass = (page: "directory" | "watchlist" | "blog" | "compare") =>
         ></path>
       </svg>
       <span>Watchlist</span>
+    </a>
+    <a href={emergingHref} class={navClass("emerging")}>
+      <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+        ></path>
+      </svg>
+      <span>Emerging & Unverified</span>
     </a>
     <a href={blogHref} class={navClass("blog")}>
       <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/components/DirectorySidebar.astro
+++ b/src/components/DirectorySidebar.astro
@@ -39,7 +39,7 @@ const navClass = (page: ActivePage) =>
         class="rounded-lg"
       />
       <div>
-        <span class="font-serif text-xl font-semibold text-rich-earth">Awesome Alt Clouds</span>
+        <span class="font-serif text-xl font-semibold text-rich-earth">Alt Cloud</span>
       </div>
     </a>
     <p class="text-[13px] text-bright-tangerine font-medium mb-1">

--- a/src/components/EmergingNavLink.astro
+++ b/src/components/EmergingNavLink.astro
@@ -1,0 +1,27 @@
+---
+import { asset } from "../lib/assets";
+import { categoryToSlug } from "../lib/clouds";
+import { EMERGING_CATEGORY } from "../lib/github";
+
+const emergingHref = asset(`categories/${categoryToSlug(EMERGING_CATEGORY)}/`);
+---
+
+<a
+  href={emergingHref}
+  class="page-link flex items-center gap-2 px-3 py-2.5 text-[13px] text-warm-stone hover:text-rich-earth hover:bg-clay-beige rounded-lg transition-colors text-left w-full no-underline">
+  <svg
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    aria-hidden="true">
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+    ></path>
+  </svg>
+  <span>Emerging & Unverified</span>
+</a>

--- a/src/content/blog/2026-06-welcome-to-alt-cloud.md
+++ b/src/content/blog/2026-06-welcome-to-alt-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Welcome to the Alt Cloud Blog
-description: A short introduction to editorial content on Awesome Alt Clouds — why we added a blog and what to expect.
+description: A short introduction to editorial content on Alt Cloud — why we added a blog and what to expect.
 publishDate: 2026-06-01
 author: Datum
 tags:
@@ -9,7 +9,7 @@ tags:
 draft: false
 ---
 
-The Awesome Alt Clouds directory has always been about one thing: helping developers find infrastructure providers that are transparent, self-service, and accountable. With more than 400 listings and growing profile pages, the site is becoming a real destination — not just a static list.
+The Alt Cloud directory has always been about one thing: helping developers find infrastructure providers that are transparent, self-service, and accountable. With more than 400 listings and growing profile pages, the site is becoming a real destination — not just a static list.
 
 This blog is where we share context the README cannot carry on its own:
 

--- a/src/content/blog/2026-06-what-is-an-alt-cloud.md
+++ b/src/content/blog/2026-06-what-is-an-alt-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: What Is an Alt Cloud?
-description: A practical definition of alternative cloud providers — and how Awesome Alt Clouds evaluates them against three inclusion criteria.
+description: A practical definition of alternative cloud providers — and how Alt Cloud evaluates them against three inclusion criteria.
 publishDate: 2026-06-10
 author: Datum
 tags:

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -68,7 +68,7 @@ const {
     <link
       rel="alternate"
       type="application/rss+xml"
-      title="Awesome Alt Clouds"
+      title="Alt Cloud"
       href={asset("rss.xml")}
     />
 
@@ -93,7 +93,7 @@ const {
                 "@type": "WebSite",
                 "@id": `${siteRoot}#website`,
                 url: homepageUrl(),
-                name: "Awesome Alt Clouds",
+                name: "Alt Cloud",
                 description: `Curated directory of ${cloudCount}+ alternative cloud providers evaluated against transparent pricing, self-service signup, and public SLA criteria.`,
                 inLanguage: "en",
                 publisher: { "@id": `${siteRoot}#organization` },
@@ -127,7 +127,7 @@ const {
               {
                 "@type": "Dataset",
                 "@id": `${siteRoot}#dataset`,
-                name: "Awesome Alt Clouds Directory",
+                name: "Alt Cloud Directory",
                 description: `A curated, community-maintained dataset of ${cloudCount}+ alternative cloud service providers evaluated against 3 criteria: transparent public pricing, usage-based self-service signup, and public SLA or status page. Covers 23 categories including infrastructure, GPU compute, databases, AI inference, developer tooling, and more.`,
                 url: homepageUrl(),
                 keywords: [
@@ -166,9 +166,8 @@ const {
                 "@type": "CollectionPage",
                 "@id": `${siteRoot}#webpage`,
                 url: homepageUrl(),
-                name: "Awesome Alt Clouds | Alternative Cloud Providers for Developers",
-                description:
-                  "Discover specialized cloud infrastructure providers built for developers who have specialized requirements and need alternatives to hyperscalers.",
+                name: defaultTitle,
+                description: defaultDescription,
                 isPartOf: { "@id": `${siteRoot}#website` },
                 about: { "@id": `${siteRoot}#dataset` },
                 speakable: {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -15,7 +15,7 @@ const { post, featuredSlugs } = Astro.props;
 const { title, description, publishDate, updatedDate, author, tags, draft, heroImage } =
   post.data;
 
-const pageTitle = `${title} | Awesome Alt Clouds`;
+const pageTitle = `${title} | Alt Cloud`;
 const canonical = absoluteUrl(`blog/${post.id}`) + "/";
 const blogIndexHref = asset("blog/");
 const ogImage = heroImage ? absoluteUrl(heroImage.replace(/^\//, "")) : undefined;

--- a/src/lib/site-meta.ts
+++ b/src/lib/site-meta.ts
@@ -39,7 +39,7 @@ export function getPageMeta(page: PageMetaKey): { title: string; description: st
 }
 
 /** Short title for Open Graph / Twitter (no preview suffix). */
-export const socialTitle = "Awesome Alt Clouds - When you need something specialized";
+export const socialTitle = "Alt Cloud - When you need something specialized";
 
 export const socialDescription =
   "A curated directory of alternative cloud providers to help developers source solutions offering public pricing, self-service signup, and transparent uptime at a glance. Now accepting contributions to the list.";

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -29,7 +29,7 @@ const featuredSlugs = [...(await getFeaturedSlugs())];
           <h1 class="font-serif text-3xl md:text-4xl font-semibold text-rich-earth mb-3">Blog</h1>
           <p class="text-warm-stone leading-relaxed max-w-2xl">
             Short-form notes on alternative cloud providers — trends, new entrants, and commentary
-            from the Awesome Alt Clouds community.
+            from the Alt Cloud community.
           </p>
         </header>
 

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -49,7 +49,7 @@ const itemListJsonLd = {
   url: canonical,
   isPartOf: {
     "@type": "WebSite",
-    name: "Awesome Alt Clouds",
+    name: "Alt Cloud",
     url: absoluteUrl(""),
   },
   mainEntity: {

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -11,6 +11,7 @@ import {
   countByCategory,
   getCategories,
 } from "../../lib/clouds";
+import { EMERGING_CATEGORY } from "../../lib/github";
 import { getFeaturedSlugs } from "../../lib/profile";
 import { siteName } from "../../lib/site-meta";
 import { absoluteUrl } from "../../lib/site-urls";
@@ -38,6 +39,7 @@ const providerCount = countByCategory(category);
 const description = getCategoryDescription(category);
 const pageTitle = `${category} | ${siteName}`;
 const canonical = `${absoluteUrl("categories/" + slug)}/`;
+const sidebarActivePage = category === EMERGING_CATEGORY ? "emerging" : "directory";
 
 const itemListJsonLd = {
   "@context": "https://schema.org",
@@ -72,7 +74,7 @@ const homeCategoryHref = `${asset("")}#${slug}`;
   </Fragment>
 
   <div class="flex flex-col md:flex-row min-h-screen">
-    <DirectorySidebar activePage="directory" />
+    <DirectorySidebar activePage={sidebarActivePage} />
 
     <main class="flex-1 p-5 md:p-8 min-w-0">
       <DetailTopBar featuredSlugs={[...featuredSlugs]} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const featuredSlugs = await getFeaturedSlugs();
         height="32"
         class="rounded-md"
       />
-      <span class="font-serif text-lg font-semibold text-rich-earth">Awesome Alt Clouds</span>
+      <span class="font-serif text-lg font-semibold text-rich-earth">Alt Cloud</span>
     </div>
     <button
       id="burgerBtn"
@@ -173,7 +173,7 @@ const featuredSlugs = await getFeaturedSlugs();
             class="rounded-lg"
           />
           <div>
-            <h1 class="font-serif text-xl font-semibold text-rich-earth">Awesome Alt Clouds</h1>
+            <h1 class="font-serif text-xl font-semibold text-rich-earth">Alt Cloud</h1>
           </div>
         </div>
         <p class="text-[13px] text-bright-tangerine font-medium mb-1">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import { asset } from "../lib/assets";
 import BlogNavLink from "../components/BlogNavLink.astro";
 import CloudCard from "../components/CloudCard.astro";
 import CompareNavLink from "../components/CompareNavLink.astro";
+import EmergingNavLink from "../components/EmergingNavLink.astro";
 import WatchlistNavLink from "../components/WatchlistNavLink.astro";
 import { clouds } from "../lib/clouds";
 import { getFeaturedSlugs } from "../lib/profile";
@@ -90,14 +91,6 @@ const featuredSlugs = await getFeaturedSlugs();
         class="flex flex-col gap-1"
         id="drawerCategoryList">
       </div>
-
-      <div class="font-serif text-xs font-semibold uppercase tracking-wider text-warm-stone mt-5 mb-3">
-        Tracking
-      </div>
-      <div
-        class="flex flex-col gap-1"
-        id="drawerTrackingList">
-      </div>
     </div>
     <div class="p-4 border-t border-clay-beige flex flex-col gap-1 flex-shrink-0">
       <a
@@ -106,6 +99,7 @@ const featuredSlugs = await getFeaturedSlugs();
         <span>+</span><span>Submit a Cloud</span>
       </a>
       <WatchlistNavLink />
+      <EmergingNavLink />
       <BlogNavLink />
       <CompareNavLink />
       <button
@@ -196,16 +190,7 @@ const featuredSlugs = await getFeaturedSlugs();
         </div>
         <div
           class="flex flex-col gap-1"
-          id="categoryList"
-          data-watchlist-href={asset("watchlist/")}>
-        </div>
-
-        <div class="font-serif text-xs font-semibold uppercase tracking-wider text-warm-stone mt-5 mb-3">
-          Tracking
-        </div>
-        <div
-          class="flex flex-col gap-1"
-          id="trackingList">
+          id="categoryList">
         </div>
       </div>
 
@@ -218,6 +203,7 @@ const featuredSlugs = await getFeaturedSlugs();
 
         <div class="flex flex-col gap-2 mb-3">
           <WatchlistNavLink />
+          <EmergingNavLink />
           <BlogNavLink />
           <CompareNavLink />
           <button
@@ -783,24 +769,17 @@ const featuredSlugs = await getFeaturedSlugs();
         }"><span>${cat}</span><span class="font-mono text-xs opacity-70">${counts[cat] || 0}</span></button>`;
       };
 
-      // "Emerging & Unverified Providers" is grouped with Watchlist in its own
-      // "Tracking" section below, not the main alphabetical category list —
-      // both are candidates that haven't fully cleared the bar yet.
+      // "Emerging & Unverified Providers" has its own persistent nav link
+      // (EmergingNavLink, next to Watchlist) instead of a spot in this
+      // alphabetical category list — both are candidates that haven't
+      // fully cleared the bar yet, and a pill buried in a long scrollable
+      // list was too easy to miss.
       const cats = getCategories().filter((cat) => cat !== EMERGING_CATEGORY);
       const html = cats.map(categoryButtonHtml).join("");
       const list = document.getElementById("categoryList");
       const drawerList = document.getElementById("drawerCategoryList");
       if (list) list.innerHTML = html;
       if (drawerList) drawerList.innerHTML = html;
-
-      const watchlistHref = list?.dataset.watchlistHref || "#";
-      const trackingHtml =
-        `<a href="${watchlistHref}" class="gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent text-warm-stone hover:bg-clay-beige hover:text-rich-earth no-underline"><span>Watchlist</span></a>` +
-        categoryButtonHtml(EMERGING_CATEGORY);
-      const trackingList = document.getElementById("trackingList");
-      const drawerTrackingList = document.getElementById("drawerTrackingList");
-      if (trackingList) trackingList.innerHTML = trackingHtml;
-      if (drawerTrackingList) drawerTrackingList.innerHTML = trackingHtml;
 
       document.querySelectorAll<HTMLElement>("[data-category]").forEach((btn) => {
         btn.addEventListener("click", () => {

--- a/tests/test_audit_emerging_badges.py
+++ b/tests/test_audit_emerging_badges.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import audit_emerging_badges as aeb
 
-SAMPLE_README = """# Awesome Alt Clouds
+SAMPLE_README = """# Alt Cloud
 
 ## Databases & Storage
 
@@ -83,7 +83,7 @@ class TestMain:
     def test_no_op_when_no_entries_found(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         no_emerging_section = (
-            "# Awesome Alt Clouds\n\n"
+            "# Alt Cloud\n\n"
             "## Databases & Storage\n\n"
             "* 🟢 [Alpha DB](https://alpha.example.com/) - A database.\n"
         )

--- a/tests/test_create_graduation_pr.py
+++ b/tests/test_create_graduation_pr.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import create_graduation_pr as cg
 
-SAMPLE_README = """# Awesome Alt Clouds
+SAMPLE_README = """# Alt Cloud
 
 ## Databases & Storage
 

--- a/tests/test_evaluate_graduation.py
+++ b/tests/test_evaluate_graduation.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import evaluate_graduation as eg
 
-SAMPLE_README = """# Awesome Alt Clouds
+SAMPLE_README = """# Alt Cloud
 
 ## Databases & Storage
 

--- a/tests/test_readme_entries.py
+++ b/tests/test_readme_entries.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from lib import readme_entries as re_lib
 
-SAMPLE_README = """# Awesome Alt Clouds
+SAMPLE_README = """# Alt Cloud
 
 ## Databases & Storage
 


### PR DESCRIPTION
## Summary

Two commits, both follow-ups from live review of #343:

**1. Move the Emerging & Unverified Providers nav link to the persistent sidebar**

Feedback on #343's "Tracking" pill-list grouping: buried in the long, scrollable Categories list, nobody would notice it. Fixed by:
- Homepage: replaced the pill-list "Tracking" sub-section with a real nav link (`EmergingNavLink`, next to Watchlist) in the persistent footer nav, matching how Watchlist/Blog/Compare already behave there.
- Every other page (Watchlist, Blog, Compare, all 22 real category pages) shares `DirectorySidebar`, which never got the original change at all — only the homepage's own duplicated sidebar markup did. Added the same link there so it's consistent site-wide, and it correctly highlights as active when you're on the Emerging category page itself (verified against build output — regular category pages still highlight "Directory", Compare still highlights "Compare").

**2. Rebrand: drop "Awesome" — now "Alt Cloud"**

Every user-facing brand mention of "Awesome Alt Clouds" → "Alt Cloud" (singular, matching the domain `alt-cloud.org` and the existing "Alt Cloud browser extension" naming): sidebar header, README/CONTRIBUTING titles, JSON-LD `name` fields, RSS title, social share title, bot comment footers (duplicate-check, evaluation), `llms.txt` headers, blog post copy.

Left unchanged (technical identifiers, not brand text): the GitHub repo slug/package name (`awesome-alt-clouds`), GitHub Pages base paths, and real `github.com`/`raw.githubusercontent.com` URLs. Also left the Home/Compare/Submit/Watchlist "Neo Cloud Comparison Tool" SEO titles from #343 untouched — that's a separate, already-decided SEO experiment, not part of this rename.

Opportunistic fix along the way: `Base.astro`'s `CollectionPage` JSON-LD had its own hardcoded, pre-SEO-update name/description instead of referencing `defaultTitle`/`defaultDescription` — now synced so it can't silently drift again.

`analysis/*.md` and `docs/superpowers/**/*.md` intentionally left untouched — `CLAUDE.md` documents these as frozen historical planning records, not live docs.

## Test plan

- [x] `npm run check` (astro check) — 0 errors
- [x] `npx eslint` on all touched files — clean
- [x] `npm run build` — 428 pages built successfully
- [x] Verified in build output: `Emerging & Unverified` link present and correctly active-highlighted on Watchlist/Compare/category/Emerging-category pages
- [x] Verified in build output: zero remaining `"Awesome Alt Clouds"` occurrences across `dist/`
- [x] `pytest tests/` — 134 passed