### PR TITLE
perf(site): speed up homepage load without reducing SSR

### DIFF
--- a/src/components/CloudCard.astro
+++ b/src/components/CloudCard.astro
@@ -7,10 +7,9 @@ import { EMERGING_CATEGORY, graduationIssueUrl } from "../lib/github";
 export interface Props {
   cloud: CloudWithSlug;
   featured: boolean;
-  index?: number;
 }
 
-const { cloud, featured, index = 0 } = Astro.props;
+const { cloud, featured } = Astro.props;
 
 const score = cloud.score ?? 3;
 const badgeClass =
@@ -30,12 +29,14 @@ const detailHref = asset(`${cloud.slug}/`);
 ---
 
 <article
-  class={`cloud-card animate-slide-up-card bg-white border border-clay-beige rounded-xl p-5 relative ${featured ? "cloud-card--featured" : ""}`}
+  class:list={[
+    "cloud-card bg-white border border-clay-beige rounded-xl p-5 relative",
+    featured && "cloud-card--featured",
+  ]}
   data-name={cloud.name.toLowerCase()}
   data-description={cloud.description.toLowerCase()}
   data-categories={cloud.categories.join("|")}
-  data-date-added={cloud.dateAdded ?? ""}
-  style={`animation-delay: ${Math.min(index, 5) * 0.05}s`}>
+  data-date-added={cloud.dateAdded ?? ""}>
   <button
     type="button"
     data-compare-toggle

--- a/src/components/CompareTray.astro
+++ b/src/components/CompareTray.astro
@@ -57,6 +57,10 @@ const baseUrl = asset("");
   const LABEL_IN = "In compare";
   const LABEL_FULL = "Full";
 
+  /** Slugs whose toggle buttons were last painted as selected / needing sync. */
+  let lastSelectedSlugs = new Set<string>();
+  let lastWasFull = false;
+
   function buildCompareUrl(slugs: string[]): string {
     const params = new URLSearchParams();
     if (slugs[0]) params.set("a", slugs[0]);
@@ -67,35 +71,77 @@ const baseUrl = asset("");
     return query ? `${path}?${query}` : path;
   }
 
-  function updateToggleButtons(): void {
-    const full = isFull();
-    document.querySelectorAll<HTMLButtonElement>("[data-compare-toggle]").forEach((btn) => {
-      const slug = btn.getAttribute("data-compare-slug") ?? "";
-      const selected = has(slug);
-      const compact = btn.hasAttribute("data-compare-compact");
-      const label = btn.querySelector("[data-compare-label]");
+  function setCompareFullAttr(full: boolean): void {
+    if (full) {
+      document.documentElement.setAttribute("data-compare-full", "");
+    } else {
+      document.documentElement.removeAttribute("data-compare-full");
+    }
+  }
 
-      btn.setAttribute("aria-pressed", selected ? "true" : "false");
-      btn.disabled = !selected && full;
+  function paintToggle(btn: HTMLButtonElement, selected: boolean, full: boolean): void {
+    const compact = btn.hasAttribute("data-compare-compact");
+    const label = btn.querySelector("[data-compare-label]");
 
-      if (label) {
-        const state = compareToggleState(selected, !selected && full);
-        label.innerHTML = compact
-          ? renderCompactCompareToggle(state)
-          : renderFullCompareToggle(state);
+    btn.setAttribute("aria-pressed", selected ? "true" : "false");
+    // Full state is CSS + click guard — avoid writing disabled on hundreds of nodes.
+    btn.removeAttribute("disabled");
+    if (!selected && full) {
+      btn.setAttribute("aria-disabled", "true");
+    } else {
+      btn.removeAttribute("aria-disabled");
+    }
 
-        if (!compact) {
-          if (selected) {
-            btn.setAttribute("aria-label", LABEL_IN);
-          } else if (full) {
-            btn.setAttribute("aria-label", LABEL_FULL);
-          } else {
-            const name = btn.getAttribute("data-compare-name") ?? "provider";
-            btn.setAttribute("aria-label", `Add ${name} to compare`);
-          }
+    if (label) {
+      const state = compareToggleState(selected, !selected && full);
+      label.innerHTML = compact
+        ? renderCompactCompareToggle(state)
+        : renderFullCompareToggle(state);
+
+      if (!compact) {
+        if (selected) {
+          btn.setAttribute("aria-label", LABEL_IN);
+        } else if (full) {
+          btn.setAttribute("aria-label", LABEL_FULL);
+        } else {
+          const name = btn.getAttribute("data-compare-name") ?? "provider";
+          btn.setAttribute("aria-label", `Add ${name} to compare`);
         }
       }
-    });
+    }
+  }
+
+  /** Update only toggles that changed selection, or all when full state flips. */
+  function updateToggleButtons(items: CompareItem[]): void {
+    const selectedSlugs = new Set(items.map((i) => i.slug));
+    const full = items.length >= 3;
+    const fullChanged = full !== lastWasFull;
+
+    setCompareFullAttr(full);
+
+    if (fullChanged) {
+      // Full ↔ not-full: selected icons and unselected labels need a pass.
+      document.querySelectorAll<HTMLButtonElement>("[data-compare-toggle]").forEach((btn) => {
+        const slug = btn.getAttribute("data-compare-slug") ?? "";
+        paintToggle(btn, selectedSlugs.has(slug), full);
+      });
+    } else {
+      const changed = new Set<string>();
+      for (const slug of selectedSlugs) {
+        if (!lastSelectedSlugs.has(slug)) changed.add(slug);
+      }
+      for (const slug of lastSelectedSlugs) {
+        if (!selectedSlugs.has(slug)) changed.add(slug);
+      }
+      for (const slug of changed) {
+        document
+          .querySelectorAll<HTMLButtonElement>(`[data-compare-toggle][data-compare-slug="${CSS.escape(slug)}"]`)
+          .forEach((btn) => paintToggle(btn, selectedSlugs.has(slug), full));
+      }
+    }
+
+    lastSelectedSlugs = selectedSlugs;
+    lastWasFull = full;
   }
 
   function renderTray(): void {
@@ -104,7 +150,12 @@ const baseUrl = asset("");
 
     if (items.length === 0) {
       tray.classList.add("hidden");
-      updateToggleButtons();
+      // Cold load / cleared: SSR toggles are already "add". Only sync if we had selection before.
+      if (lastSelectedSlugs.size > 0 || lastWasFull) {
+        updateToggleButtons(items);
+      } else {
+        setCompareFullAttr(false);
+      }
       return;
     }
 
@@ -123,7 +174,7 @@ const baseUrl = asset("");
       .join("");
 
     goBtn.textContent = `Compare (${items.length})`;
-    updateToggleButtons();
+    updateToggleButtons(items);
   }
 
   function escapeHtml(text: string): string {
@@ -137,11 +188,14 @@ const baseUrl = asset("");
   function handleToggleClick(event: Event): void {
     const target = event.target as HTMLElement;
     const btn = target.closest<HTMLButtonElement>("[data-compare-toggle]");
-    if (!btn || btn.disabled) return;
+    if (!btn) return;
 
     const slug = btn.getAttribute("data-compare-slug");
     const name = btn.getAttribute("data-compare-name");
     if (!slug || !name) return;
+
+    const selected = has(slug);
+    if (!selected && isFull()) return;
 
     event.preventDefault();
     event.stopPropagation();

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -81,8 +81,17 @@ const {
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
-      onload="this.onload=null;this.rel='stylesheet'"
+      id="google-fonts-css"
     />
+    <script is:inline>
+      (function () {
+        const el = document.getElementById("google-fonts-css");
+        if (!el) return;
+        el.addEventListener("load", function () {
+          el.rel = "stylesheet";
+        });
+      })();
+    </script>
     <noscript>
       <link
         rel="stylesheet"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -76,10 +76,19 @@ const {
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://www.google.com" />
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
 
     {
       includeHomeJsonLd && (

--- a/src/pages/categories/[slug].astro
+++ b/src/pages/categories/[slug].astro
@@ -114,11 +114,10 @@ const homeCategoryHref = `${asset("")}#${slug}`;
             <p class="text-warm-stone py-8">No providers in this category yet.</p>
           ) : (
             <div class="grid gap-4 grid-cols-[repeat(auto-fill,minmax(300px,1fr))] md:grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
-              {categoryClouds.map((cloud, index) => (
+              {categoryClouds.map((cloud) => (
                 <CloudCard
                   cloud={cloud}
                   featured={featuredSlugs.has(cloud.slug)}
-                  index={index}
                 />
               ))}
             </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,12 +6,26 @@ import CloudCard from "../components/CloudCard.astro";
 import CompareNavLink from "../components/CompareNavLink.astro";
 import EmergingNavLink from "../components/EmergingNavLink.astro";
 import WatchlistNavLink from "../components/WatchlistNavLink.astro";
-import { clouds } from "../lib/clouds";
+import { clouds, countByCategory, getCategories } from "../lib/clouds";
+import { EMERGING_CATEGORY } from "../lib/github";
 import { getFeaturedSlugs } from "../lib/profile";
 
 const sortedClouds = [...clouds].sort((a, b) => a.name.localeCompare(b.name));
 const cloudCount = clouds.length;
 const featuredSlugs = await getFeaturedSlugs();
+
+/** Sidebar categories (Emerging has its own nav link). */
+const sidebarCategories = getCategories()
+  .filter((cat) => cat !== EMERGING_CATEGORY)
+  .map((cat) => ({ name: cat, count: countByCategory(cat) }));
+
+const categoryBtnClass = (active: boolean) =>
+  [
+    "gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent",
+    active
+      ? "bg-rich-earth text-cream font-medium"
+      : "text-warm-stone hover:bg-clay-beige hover:text-rich-earth",
+  ].join(" ");
 ---
 
 <Base
@@ -90,6 +104,17 @@ const featuredSlugs = await getFeaturedSlugs();
       <div
         class="flex flex-col gap-1"
         id="drawerCategoryList">
+        {
+          sidebarCategories.map(({ name, count }) => (
+            <button
+              type="button"
+              data-category={name}
+              class={categoryBtnClass(name === "All")}>
+              <span>{name}</span>
+              <span class="font-mono text-xs opacity-70">{count}</span>
+            </button>
+          ))
+        }
       </div>
     </div>
     <div class="p-4 border-t border-clay-beige flex flex-col gap-1 flex-shrink-0">
@@ -191,6 +216,17 @@ const featuredSlugs = await getFeaturedSlugs();
         <div
           class="flex flex-col gap-1"
           id="categoryList">
+          {
+            sidebarCategories.map(({ name, count }) => (
+              <button
+                type="button"
+                data-category={name}
+                class={categoryBtnClass(name === "All")}>
+                <span>{name}</span>
+                <span class="font-mono text-xs opacity-70">{count}</span>
+              </button>
+            ))
+          }
         </div>
       </div>
 
@@ -320,15 +356,17 @@ const featuredSlugs = await getFeaturedSlugs();
       </div>
 
       <!-- Clouds grid (SSR'd from clouds.json, hydrated by client JS) -->
+      <script is:inline>
+        document.documentElement.classList.add("card-reveal-pending");
+      </script>
       <div
         id="cloudsGrid"
         class="grid gap-4 grid-cols-[repeat(auto-fill,minmax(300px,1fr))] md:grid-cols-[repeat(auto-fill,minmax(320px,1fr))]">
         {
-          sortedClouds.map((cloud, index) => (
+          sortedClouds.map((cloud) => (
             <CloudCard
               cloud={cloud}
               featured={featuredSlugs.has(cloud.slug)}
-              index={index}
             />
           ))
         }
@@ -612,32 +650,17 @@ const featuredSlugs = await getFeaturedSlugs();
     </div>
   </div>
 
-  <!-- Hydration data: serialized clouds for client-side filter/search/sort -->
-  <script
-    is:inline
-    id="clouds-data"
-    type="application/json"
-    set:html={JSON.stringify(sortedClouds)}
-  />
-
   <script>
-    import { EMERGING_CATEGORY } from "../lib/github";
-
-    type Cloud = {
-      name: string;
-      url: string;
-      description: string;
-      score: 2 | 3;
-      categories: string[];
-      dateAdded?: string;
-    };
-
-    const dataEl = document.getElementById("clouds-data");
-    const altClouds: Cloud[] = dataEl ? JSON.parse(dataEl.textContent || "[]") : [];
-
     let currentCategory = "All";
     let searchTerm = "";
     let currentSort: "alphabetical" | "recent" = "alphabetical";
+    /** Last sort applied to DOM order — skip reorder when unchanged. */
+    let appliedSort: "alphabetical" | "recent" = "alphabetical";
+
+    const ACTIVE_CAT =
+      "bg-rich-earth text-cream font-medium gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent";
+    const INACTIVE_CAT =
+      "text-warm-stone hover:bg-clay-beige hover:text-rich-earth gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent";
 
     const MODAL_HASHES: Record<string, string> = {
       aboutModal: "about",
@@ -655,15 +678,17 @@ const featuredSlugs = await getFeaturedSlugs();
         .replace(/^-|-$/g, "");
     }
 
-    function slugToCategory(slug: string): string {
-      const cats = getCategories();
-      return cats.find((c) => categoryToSlug(c) === slug) || "All";
+    /** Category names from SSR'd sidebar buttons (desktop list is the source of truth). */
+    function getCategoryNames(): string[] {
+      const list = document.getElementById("categoryList");
+      if (!list) return ["All"];
+      return Array.from(list.querySelectorAll<HTMLElement>("[data-category]")).map(
+        (btn) => btn.getAttribute("data-category") || ""
+      );
     }
 
-    function getCategories(): string[] {
-      const set = new Set<string>();
-      for (const c of altClouds) for (const cat of c.categories) set.add(cat);
-      return ["All", ...[...set].sort()];
+    function slugToCategory(slug: string): string {
+      return getCategoryNames().find((c) => categoryToSlug(c) === slug) || "All";
     }
 
     function openModal(id: string) {
@@ -753,51 +778,46 @@ const featuredSlugs = await getFeaturedSlugs();
       document.body.style.overflow = "";
     });
 
-    // Categories rendering
-    function renderCategories() {
-      const counts: Record<string, number> = { All: altClouds.length };
-      for (const c of altClouds) {
-        for (const cat of c.categories) counts[cat] = (counts[cat] || 0) + 1;
-      }
-
-      const categoryButtonHtml = (cat: string) => {
-        const isActive = cat === currentCategory;
-        return `<button data-category="${cat.replace(/"/g, "&quot;")}" class="gap-2 [&>span]:text-left category-item flex justify-between items-center px-3 py-2 rounded-lg cursor-pointer text-sm transition-all border border-transparent ${
-          isActive
-            ? "bg-rich-earth text-cream font-medium"
-            : "text-warm-stone hover:bg-clay-beige hover:text-rich-earth"
-        }"><span>${cat}</span><span class="font-mono text-xs opacity-70">${counts[cat] || 0}</span></button>`;
-      };
-
-      // "Emerging & Unverified Providers" has its own persistent nav link
-      // (EmergingNavLink, next to Watchlist) instead of a spot in this
-      // alphabetical category list — both are candidates that haven't
-      // fully cleared the bar yet, and a pill buried in a long scrollable
-      // list was too easy to miss.
-      const cats = getCategories().filter((cat) => cat !== EMERGING_CATEGORY);
-      const html = cats.map(categoryButtonHtml).join("");
-      const list = document.getElementById("categoryList");
-      const drawerList = document.getElementById("drawerCategoryList");
-      if (list) list.innerHTML = html;
-      if (drawerList) drawerList.innerHTML = html;
-
+    function updateCategoryActiveState() {
       document.querySelectorAll<HTMLElement>("[data-category]").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          const cat = btn.getAttribute("data-category");
-          if (cat) filterByCategory(cat);
-        });
+        const cat = btn.getAttribute("data-category");
+        btn.className = cat === currentCategory ? ACTIVE_CAT : INACTIVE_CAT;
       });
     }
 
     function filterByCategory(cat: string) {
       currentCategory = cat;
-      renderCategories();
+      updateCategoryActiveState();
       applyFilters();
       updateUrl();
       closeDrawer();
     }
 
-    function applyFilters() {
+    document.querySelectorAll<HTMLElement>("[data-category]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const cat = btn.getAttribute("data-category");
+        if (cat) filterByCategory(cat);
+      });
+    });
+
+    function compareCards(a: HTMLElement, b: HTMLElement): number {
+      if (currentSort === "alphabetical") {
+        return (a.dataset.name || "").localeCompare(b.dataset.name || "");
+      }
+      const da = a.dataset.dateAdded || "";
+      const db = b.dataset.dateAdded || "";
+      if (!da && !db) return 0;
+      if (!da) return 1;
+      if (!db) return -1;
+      return db.localeCompare(da);
+    }
+
+    function clearCardRevealAnimation(card: HTMLElement): void {
+      card.classList.remove("animate-slide-up-card");
+      card.style.removeProperty("animation-delay");
+    }
+
+    function applyFilters(options: { reorder?: boolean } = {}) {
       const grid = document.getElementById("cloudsGrid");
       const empty = document.getElementById("emptyState");
       if (!grid) return;
@@ -806,7 +826,6 @@ const featuredSlugs = await getFeaturedSlugs();
       const term = searchTerm.toLowerCase();
       let visibleCount = 0;
 
-      const matches: HTMLElement[] = [];
       for (const card of cards) {
         const cats = (card.dataset.categories || "").split("|");
         const name = card.dataset.name || "";
@@ -815,27 +834,22 @@ const featuredSlugs = await getFeaturedSlugs();
         const inSearch = term === "" || name.includes(term) || desc.includes(term);
         if (inCat && inSearch) {
           card.classList.remove("hidden");
-          matches.push(card);
           visibleCount++;
         } else {
           card.classList.add("hidden");
         }
+        // Filter toggles hidden/display and can retrigger CSS animations — strip reveal class.
+        clearCardRevealAnimation(card);
       }
 
-      // Apply sort by reordering DOM
-      matches.sort((a, b) => {
-        if (currentSort === "alphabetical") {
-          return (a.dataset.name || "").localeCompare(b.dataset.name || "");
-        }
-        const da = a.dataset.dateAdded || "";
-        const db = b.dataset.dateAdded || "";
-        if (!da && !db) return 0;
-        if (!da) return 1;
-        if (!db) return -1;
-        return db.localeCompare(da);
-      });
-
-      for (const card of matches) grid.appendChild(card);
+      // Reorder only when sort mode changes (SSR order is already alphabetical).
+      if (options.reorder || currentSort !== appliedSort) {
+        cards.sort(compareCards);
+        const fragment = document.createDocumentFragment();
+        for (const card of cards) fragment.appendChild(card);
+        grid.appendChild(fragment);
+        appliedSort = currentSort;
+      }
 
       if (empty) {
         empty.classList.toggle("hidden", visibleCount > 0);
@@ -845,6 +859,7 @@ const featuredSlugs = await getFeaturedSlugs();
     // Search input
     const searchInput = document.getElementById("searchInput") as HTMLInputElement | null;
     const searchClear = document.getElementById("searchClear");
+    let searchDebounce: ReturnType<typeof setTimeout> | undefined;
 
     function updateSearchClear() {
       if (!searchClear) return;
@@ -864,8 +879,11 @@ const featuredSlugs = await getFeaturedSlugs();
     searchInput?.addEventListener("input", (e) => {
       searchTerm = (e.target as HTMLInputElement).value;
       updateSearchClear();
-      applyFilters();
-      updateUrl();
+      clearTimeout(searchDebounce);
+      searchDebounce = setTimeout(() => {
+        applyFilters();
+        updateUrl();
+      }, 120);
     });
     searchClear?.addEventListener("click", clearSearch);
 
@@ -873,7 +891,7 @@ const featuredSlugs = await getFeaturedSlugs();
     const sortSelect = document.getElementById("sortSelect") as HTMLSelectElement | null;
     sortSelect?.addEventListener("change", () => {
       currentSort = (sortSelect.value as "alphabetical" | "recent") || "alphabetical";
-      applyFilters();
+      applyFilters({ reorder: true });
     });
 
     function updateUrl() {
@@ -905,15 +923,66 @@ const featuredSlugs = await getFeaturedSlugs();
       updateSearchClear();
       const slug = location.hash.slice(1);
       currentCategory = slug && !HASH_MODALS[slug] ? slugToCategory(slug) : "All";
-      renderCategories();
+      updateCategoryActiveState();
       applyFilters();
     });
 
-    // Init
+    // Init — skip filter/reorder when URL has no search or category hash
     initFromUrl();
     updateSearchClear();
-    renderCategories();
-    applyFilters();
+    updateCategoryActiveState();
+    if (searchTerm !== "" || currentCategory !== "All") {
+      applyFilters();
+    }
+
+    /** Reveal-animate only cards that intersect the viewport on first paint (once). */
+    let initialRevealDone = false;
+
+    function revealViewportCards() {
+      if (initialRevealDone) return;
+
+      const grid = document.getElementById("cloudsGrid");
+      if (!grid) {
+        document.documentElement.classList.remove("card-reveal-pending");
+        initialRevealDone = true;
+        return;
+      }
+
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        document.documentElement.classList.remove("card-reveal-pending");
+        initialRevealDone = true;
+        return;
+      }
+
+      const cards = Array.from(grid.querySelectorAll<HTMLElement>("article.cloud-card"));
+      const viewportTop = 0;
+      const viewportBottom = window.innerHeight;
+      let delayIndex = 0;
+
+      for (const card of cards) {
+        if (card.classList.contains("hidden")) continue;
+        const rect = card.getBoundingClientRect();
+        const inViewport = rect.top < viewportBottom && rect.bottom > viewportTop;
+        if (!inViewport) continue;
+
+        card.style.animationDelay = `${Math.min(delayIndex, 5) * 50}ms`;
+        card.classList.add("animate-slide-up-card");
+        card.addEventListener(
+          "animationend",
+          () => clearCardRevealAnimation(card),
+          { once: true }
+        );
+        delayIndex++;
+      }
+
+      document.documentElement.classList.remove("card-reveal-pending");
+      initialRevealDone = true;
+    }
+
+    // Wait for layout so getBoundingClientRect reflects the real grid.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(revealViewportCards);
+    });
 
     // Open modal if loaded with hash
     const initModalId = HASH_MODALS[location.hash.slice(1)];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -64,6 +64,24 @@
   }
 }
 
+/* Skip layout/paint for off-screen directory cards; cards stay in the DOM. */
+.cloud-card {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 260px;
+}
+
+/* Hide cards until JS measures the viewport (inline script sets this class). */
+html.card-reveal-pending #cloudsGrid > .cloud-card {
+  opacity: 0;
+}
+
+/* When compare basket is full, dim unselected toggles without touching 471 nodes. */
+html[data-compare-full] [data-compare-toggle]:not([aria-pressed="true"]) {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .prose-content {
   color: var(--color-rich-earth);
   line-height: 1.7;


### PR DESCRIPTION
Skip layout/paint for off-screen cards, SSR category sidebar, remove 141KB inline clouds JSON, and avoid mass DOM work on init. Reveal animation runs once for viewport cards only; filter/search no longer re-triggers it.